### PR TITLE
Rename the placeholders to the latest name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## minimum-valuable-dev-protocol-app
+## stakes.social
 
 ### how to run on local
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "minimum-valuable-dev-protocol-app",
+  "name": "stakes.social",
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Proposed Changes

I renamed the placeholders to the latest(official) name.

## Implementation

- rename `minimum-valuable-dev-protocol-app` ➝ `stakes.social`