### PR TITLE
feat: error modal for checking Ethereum plugin

### DIFF
--- a/packages/web/src/pages/_app.tsx
+++ b/packages/web/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { Modal } from 'antd'
 import App, { AppInitialProps } from 'next/app'
 import { WithApolloProps } from 'next-with-apollo'
 import Head from 'next/head'
@@ -7,6 +8,16 @@ import withApollo from 'src/fixtures/withApollo'
 class NextApp extends App<AppInitialProps & WithApolloProps<{}>> {
   componentDidCatch = (error: Error, errorInfo: React.ErrorInfo) => {
     super.componentDidCatch(error, errorInfo)
+  }
+
+  componentDidMount = () => {
+    const { ethereum } = window
+    if (!ethereum) {
+      Modal.error({
+        title: 'This is an error message',
+        content: 'some messages...some messages...'
+      })
+    }
   }
 
   render() {

--- a/packages/web/src/pages/_app.tsx
+++ b/packages/web/src/pages/_app.tsx
@@ -13,6 +13,7 @@ class NextApp extends App<AppInitialProps & WithApolloProps<{}>> {
   componentDidMount = () => {
     const { ethereum } = window
     if (!ethereum) {
+      // TODO: fix design and messages.
       Modal.error({
         title: 'This is an error message',
         content: 'some messages...some messages...'


### PR DESCRIPTION
## Proposed Changes

- as with the title

![スクリーンショット 2020-04-25 22 22 33](https://user-images.githubusercontent.com/16770233/80281184-62014e00-8744-11ea-9ffd-6f50a24b42bb.png)

I checked that this works in both browsers with and without `Metamask` installed.

## Implementation

- error modal