### PR TITLE
Supports sorted properties list

### DIFF
--- a/packages/graphql/src/queries/listPropertyCreateFactory.graphql
+++ b/packages/graphql/src/queries/listPropertyCreateFactory.graphql
@@ -1,5 +1,11 @@
 query ListProperty($limit: Int, $offset: Int) {
-  property_factory_create(limit: $limit, offset: $offset) {
+  property_factory_create(limit: $limit, offset: $offset, order_by: {
+    property_n_allocation_aggregate: {
+      sum: {
+        result: desc_nulls_last
+      }
+    }
+  }) {
     ...propertyFactoryCreate
   }
   property_factory_create_aggregate {

--- a/packages/graphql/src/queries/listPropertyCreateFactory.graphql
+++ b/packages/graphql/src/queries/listPropertyCreateFactory.graphql
@@ -1,6 +1,6 @@
 query ListProperty($limit: Int, $offset: Int) {
   property_factory_create(limit: $limit, offset: $offset, order_by: {
-    property_n_allocation_aggregate: {
+    allocation_aggregate: {
       sum: {
         result: desc_nulls_last
       }

--- a/packages/graphql/src/react-apollo/generated.tsx
+++ b/packages/graphql/src/react-apollo/generated.tsx
@@ -18,6 +18,9 @@ export type Scalars = {
 
 export type Allocator_Allocation_Result = {
   __typename?: 'allocator_allocation_result'
+  allocation_n_authentication?: Maybe<Property_Authentication>
+  allocation_n_property?: Maybe<Property_Factory_Create>
+  allocation_n_reward?: Maybe<Reward_Calculation_Result>
   arg_value: Scalars['numeric']
   block_number: Scalars['Int']
   event_id: Scalars['String']
@@ -99,6 +102,9 @@ export type Allocator_Allocation_Result_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Allocator_Allocation_Result_Bool_Exp>>>
   _not?: Maybe<Allocator_Allocation_Result_Bool_Exp>
   _or?: Maybe<Array<Maybe<Allocator_Allocation_Result_Bool_Exp>>>
+  allocation_n_authentication?: Maybe<Property_Authentication_Bool_Exp>
+  allocation_n_property?: Maybe<Property_Factory_Create_Bool_Exp>
+  allocation_n_reward?: Maybe<Reward_Calculation_Result_Bool_Exp>
   arg_value?: Maybe<Numeric_Comparison_Exp>
   block_number?: Maybe<Int_Comparison_Exp>
   event_id?: Maybe<String_Comparison_Exp>
@@ -117,12 +123,18 @@ export enum Allocator_Allocation_Result_Constraint {
 }
 
 export type Allocator_Allocation_Result_Inc_Input = {
+  arg_value?: Maybe<Scalars['numeric']>
   block_number?: Maybe<Scalars['Int']>
+  lockup_value?: Maybe<Scalars['numeric']>
   log_index?: Maybe<Scalars['Int']>
+  result?: Maybe<Scalars['numeric']>
   transaction_index?: Maybe<Scalars['Int']>
 }
 
 export type Allocator_Allocation_Result_Insert_Input = {
+  allocation_n_authentication?: Maybe<Property_Authentication_Obj_Rel_Insert_Input>
+  allocation_n_property?: Maybe<Property_Factory_Create_Obj_Rel_Insert_Input>
+  allocation_n_reward?: Maybe<Reward_Calculation_Result_Obj_Rel_Insert_Input>
   arg_value?: Maybe<Scalars['numeric']>
   block_number?: Maybe<Scalars['Int']>
   event_id?: Maybe<Scalars['String']>
@@ -212,6 +224,9 @@ export type Allocator_Allocation_Result_On_Conflict = {
 }
 
 export type Allocator_Allocation_Result_Order_By = {
+  allocation_n_authentication?: Maybe<Property_Authentication_Order_By>
+  allocation_n_property?: Maybe<Property_Factory_Create_Order_By>
+  allocation_n_reward?: Maybe<Reward_Calculation_Result_Order_By>
   arg_value?: Maybe<Order_By>
   block_number?: Maybe<Order_By>
   event_id?: Maybe<Order_By>
@@ -223,6 +238,10 @@ export type Allocator_Allocation_Result_Order_By = {
   raw_data?: Maybe<Order_By>
   result?: Maybe<Order_By>
   transaction_index?: Maybe<Order_By>
+}
+
+export type Allocator_Allocation_Result_Pk_Columns_Input = {
+  event_id: Scalars['String']
 }
 
 export enum Allocator_Allocation_Result_Select_Column {
@@ -507,8 +526,14 @@ export enum Allocator_Before_Allocation_Constraint {
 }
 
 export type Allocator_Before_Allocation_Inc_Input = {
+  assets?: Maybe<Scalars['numeric']>
   block_number?: Maybe<Scalars['Int']>
+  blocks?: Maybe<Scalars['numeric']>
   log_index?: Maybe<Scalars['Int']>
+  market_value?: Maybe<Scalars['numeric']>
+  mint?: Maybe<Scalars['numeric']>
+  token_value?: Maybe<Scalars['numeric']>
+  total_assets?: Maybe<Scalars['numeric']>
   transaction_index?: Maybe<Scalars['Int']>
 }
 
@@ -613,6 +638,10 @@ export type Allocator_Before_Allocation_Order_By = {
   token_value?: Maybe<Order_By>
   total_assets?: Maybe<Order_By>
   transaction_index?: Maybe<Order_By>
+}
+
+export type Allocator_Before_Allocation_Pk_Columns_Input = {
+  event_id: Scalars['String']
 }
 
 export enum Allocator_Before_Allocation_Select_Column {
@@ -885,11 +914,30 @@ export type Lockup_Lockedup = {
   block_number: Scalars['Int']
   event_id: Scalars['String']
   from_address: Scalars['String']
+  lockup_n_allocation: Array<Allocator_Allocation_Result>
+  lockup_n_allocation_aggregate: Allocator_Allocation_Result_Aggregate
+  lockup_n_property?: Maybe<Property_Factory_Create>
   log_index: Scalars['Int']
   property: Scalars['String']
   raw_data: Scalars['String']
   token_value: Scalars['numeric']
   transaction_index: Scalars['Int']
+}
+
+export type Lockup_LockedupLockup_N_AllocationArgs = {
+  distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Allocator_Allocation_Result_Order_By>>
+  where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+}
+
+export type Lockup_LockedupLockup_N_Allocation_AggregateArgs = {
+  distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Allocator_Allocation_Result_Order_By>>
+  where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
 }
 
 export type Lockup_Lockedup_Aggregate = {
@@ -959,6 +1007,8 @@ export type Lockup_Lockedup_Bool_Exp = {
   block_number?: Maybe<Int_Comparison_Exp>
   event_id?: Maybe<String_Comparison_Exp>
   from_address?: Maybe<String_Comparison_Exp>
+  lockup_n_allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+  lockup_n_property?: Maybe<Property_Factory_Create_Bool_Exp>
   log_index?: Maybe<Int_Comparison_Exp>
   property?: Maybe<String_Comparison_Exp>
   raw_data?: Maybe<String_Comparison_Exp>
@@ -973,6 +1023,7 @@ export enum Lockup_Lockedup_Constraint {
 export type Lockup_Lockedup_Inc_Input = {
   block_number?: Maybe<Scalars['Int']>
   log_index?: Maybe<Scalars['Int']>
+  token_value?: Maybe<Scalars['numeric']>
   transaction_index?: Maybe<Scalars['Int']>
 }
 
@@ -980,6 +1031,8 @@ export type Lockup_Lockedup_Insert_Input = {
   block_number?: Maybe<Scalars['Int']>
   event_id?: Maybe<Scalars['String']>
   from_address?: Maybe<Scalars['String']>
+  lockup_n_allocation?: Maybe<Allocator_Allocation_Result_Arr_Rel_Insert_Input>
+  lockup_n_property?: Maybe<Property_Factory_Create_Obj_Rel_Insert_Input>
   log_index?: Maybe<Scalars['Int']>
   property?: Maybe<Scalars['String']>
   raw_data?: Maybe<Scalars['String']>
@@ -1054,11 +1107,17 @@ export type Lockup_Lockedup_Order_By = {
   block_number?: Maybe<Order_By>
   event_id?: Maybe<Order_By>
   from_address?: Maybe<Order_By>
+  lockup_n_allocation_aggregate?: Maybe<Allocator_Allocation_Result_Aggregate_Order_By>
+  lockup_n_property?: Maybe<Property_Factory_Create_Order_By>
   log_index?: Maybe<Order_By>
   property?: Maybe<Order_By>
   raw_data?: Maybe<Order_By>
   token_value?: Maybe<Order_By>
   transaction_index?: Maybe<Order_By>
+}
+
+export type Lockup_Lockedup_Pk_Columns_Input = {
+  event_id: Scalars['String']
 }
 
 export enum Lockup_Lockedup_Select_Column {
@@ -1206,8 +1265,62 @@ export type Market_Factory_Create = {
   from_address: Scalars['String']
   log_index: Scalars['Int']
   market: Scalars['String']
+  market_n_allocation: Array<Allocator_Allocation_Result>
+  market_n_allocation_aggregate: Allocator_Allocation_Result_Aggregate
+  market_n_metrics: Array<Metrics_Factory_Create>
+  market_n_metrics_aggregate: Metrics_Factory_Create_Aggregate
+  market_n_metrics_destroy: Array<Metrics_Factory_Destroy>
+  market_n_metrics_destroy_aggregate: Metrics_Factory_Destroy_Aggregate
   raw_data: Scalars['String']
   transaction_index: Scalars['Int']
+}
+
+export type Market_Factory_CreateMarket_N_AllocationArgs = {
+  distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Allocator_Allocation_Result_Order_By>>
+  where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+}
+
+export type Market_Factory_CreateMarket_N_Allocation_AggregateArgs = {
+  distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Allocator_Allocation_Result_Order_By>>
+  where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+}
+
+export type Market_Factory_CreateMarket_N_MetricsArgs = {
+  distinct_on?: Maybe<Array<Metrics_Factory_Create_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Metrics_Factory_Create_Order_By>>
+  where?: Maybe<Metrics_Factory_Create_Bool_Exp>
+}
+
+export type Market_Factory_CreateMarket_N_Metrics_AggregateArgs = {
+  distinct_on?: Maybe<Array<Metrics_Factory_Create_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Metrics_Factory_Create_Order_By>>
+  where?: Maybe<Metrics_Factory_Create_Bool_Exp>
+}
+
+export type Market_Factory_CreateMarket_N_Metrics_DestroyArgs = {
+  distinct_on?: Maybe<Array<Metrics_Factory_Destroy_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Metrics_Factory_Destroy_Order_By>>
+  where?: Maybe<Metrics_Factory_Destroy_Bool_Exp>
+}
+
+export type Market_Factory_CreateMarket_N_Metrics_Destroy_AggregateArgs = {
+  distinct_on?: Maybe<Array<Metrics_Factory_Destroy_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Metrics_Factory_Destroy_Order_By>>
+  where?: Maybe<Metrics_Factory_Destroy_Bool_Exp>
 }
 
 export type Market_Factory_Create_Aggregate = {
@@ -1277,6 +1390,9 @@ export type Market_Factory_Create_Bool_Exp = {
   from_address?: Maybe<String_Comparison_Exp>
   log_index?: Maybe<Int_Comparison_Exp>
   market?: Maybe<String_Comparison_Exp>
+  market_n_allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+  market_n_metrics?: Maybe<Metrics_Factory_Create_Bool_Exp>
+  market_n_metrics_destroy?: Maybe<Metrics_Factory_Destroy_Bool_Exp>
   raw_data?: Maybe<String_Comparison_Exp>
   transaction_index?: Maybe<Int_Comparison_Exp>
 }
@@ -1297,6 +1413,9 @@ export type Market_Factory_Create_Insert_Input = {
   from_address?: Maybe<Scalars['String']>
   log_index?: Maybe<Scalars['Int']>
   market?: Maybe<Scalars['String']>
+  market_n_allocation?: Maybe<Allocator_Allocation_Result_Arr_Rel_Insert_Input>
+  market_n_metrics?: Maybe<Metrics_Factory_Create_Arr_Rel_Insert_Input>
+  market_n_metrics_destroy?: Maybe<Metrics_Factory_Destroy_Arr_Rel_Insert_Input>
   raw_data?: Maybe<Scalars['String']>
   transaction_index?: Maybe<Scalars['Int']>
 }
@@ -1366,8 +1485,15 @@ export type Market_Factory_Create_Order_By = {
   from_address?: Maybe<Order_By>
   log_index?: Maybe<Order_By>
   market?: Maybe<Order_By>
+  market_n_allocation_aggregate?: Maybe<Allocator_Allocation_Result_Aggregate_Order_By>
+  market_n_metrics_aggregate?: Maybe<Metrics_Factory_Create_Aggregate_Order_By>
+  market_n_metrics_destroy_aggregate?: Maybe<Metrics_Factory_Destroy_Aggregate_Order_By>
   raw_data?: Maybe<Order_By>
   transaction_index?: Maybe<Order_By>
+}
+
+export type Market_Factory_Create_Pk_Columns_Input = {
+  event_id: Scalars['String']
 }
 
 export enum Market_Factory_Create_Select_Column {
@@ -1498,6 +1624,8 @@ export type Metrics_Factory_Create = {
   from_address: Scalars['String']
   log_index: Scalars['Int']
   metrics: Scalars['String']
+  metrics_n_market?: Maybe<Market_Factory_Create>
+  metrics_n_metrics_destroy?: Maybe<Metrics_Factory_Destroy>
   raw_data: Scalars['String']
   transaction_index: Scalars['Int']
 }
@@ -1569,6 +1697,8 @@ export type Metrics_Factory_Create_Bool_Exp = {
   from_address?: Maybe<String_Comparison_Exp>
   log_index?: Maybe<Int_Comparison_Exp>
   metrics?: Maybe<String_Comparison_Exp>
+  metrics_n_market?: Maybe<Market_Factory_Create_Bool_Exp>
+  metrics_n_metrics_destroy?: Maybe<Metrics_Factory_Destroy_Bool_Exp>
   raw_data?: Maybe<String_Comparison_Exp>
   transaction_index?: Maybe<Int_Comparison_Exp>
 }
@@ -1589,6 +1719,8 @@ export type Metrics_Factory_Create_Insert_Input = {
   from_address?: Maybe<Scalars['String']>
   log_index?: Maybe<Scalars['Int']>
   metrics?: Maybe<Scalars['String']>
+  metrics_n_market?: Maybe<Market_Factory_Create_Obj_Rel_Insert_Input>
+  metrics_n_metrics_destroy?: Maybe<Metrics_Factory_Destroy_Obj_Rel_Insert_Input>
   raw_data?: Maybe<Scalars['String']>
   transaction_index?: Maybe<Scalars['Int']>
 }
@@ -1658,8 +1790,14 @@ export type Metrics_Factory_Create_Order_By = {
   from_address?: Maybe<Order_By>
   log_index?: Maybe<Order_By>
   metrics?: Maybe<Order_By>
+  metrics_n_market?: Maybe<Market_Factory_Create_Order_By>
+  metrics_n_metrics_destroy?: Maybe<Metrics_Factory_Destroy_Order_By>
   raw_data?: Maybe<Order_By>
   transaction_index?: Maybe<Order_By>
+}
+
+export type Metrics_Factory_Create_Pk_Columns_Input = {
+  event_id: Scalars['String']
 }
 
 export enum Metrics_Factory_Create_Select_Column {
@@ -1790,6 +1928,8 @@ export type Metrics_Factory_Destroy = {
   from_address: Scalars['String']
   log_index: Scalars['Int']
   metrics: Scalars['String']
+  metrics_destroy_n_market?: Maybe<Market_Factory_Create>
+  metrics_destroy_n_metrics?: Maybe<Metrics_Factory_Create>
   raw_data: Scalars['String']
   transaction_index: Scalars['Int']
 }
@@ -1861,6 +2001,8 @@ export type Metrics_Factory_Destroy_Bool_Exp = {
   from_address?: Maybe<String_Comparison_Exp>
   log_index?: Maybe<Int_Comparison_Exp>
   metrics?: Maybe<String_Comparison_Exp>
+  metrics_destroy_n_market?: Maybe<Market_Factory_Create_Bool_Exp>
+  metrics_destroy_n_metrics?: Maybe<Metrics_Factory_Create_Bool_Exp>
   raw_data?: Maybe<String_Comparison_Exp>
   transaction_index?: Maybe<Int_Comparison_Exp>
 }
@@ -1881,6 +2023,8 @@ export type Metrics_Factory_Destroy_Insert_Input = {
   from_address?: Maybe<Scalars['String']>
   log_index?: Maybe<Scalars['Int']>
   metrics?: Maybe<Scalars['String']>
+  metrics_destroy_n_market?: Maybe<Market_Factory_Create_Obj_Rel_Insert_Input>
+  metrics_destroy_n_metrics?: Maybe<Metrics_Factory_Create_Obj_Rel_Insert_Input>
   raw_data?: Maybe<Scalars['String']>
   transaction_index?: Maybe<Scalars['Int']>
 }
@@ -1950,8 +2094,14 @@ export type Metrics_Factory_Destroy_Order_By = {
   from_address?: Maybe<Order_By>
   log_index?: Maybe<Order_By>
   metrics?: Maybe<Order_By>
+  metrics_destroy_n_market?: Maybe<Market_Factory_Create_Order_By>
+  metrics_destroy_n_metrics?: Maybe<Metrics_Factory_Create_Order_By>
   raw_data?: Maybe<Order_By>
   transaction_index?: Maybe<Order_By>
+}
+
+export type Metrics_Factory_Destroy_Pk_Columns_Input = {
+  event_id: Scalars['String']
 }
 
 export enum Metrics_Factory_Destroy_Select_Column {
@@ -2078,86 +2228,170 @@ export type Metrics_Factory_Destroy_Variance_Order_By = {
 export type Mutation_Root = {
   __typename?: 'mutation_root'
   delete_allocator_allocation_result?: Maybe<Allocator_Allocation_Result_Mutation_Response>
+  delete_allocator_allocation_result_by_pk?: Maybe<Allocator_Allocation_Result>
   delete_allocator_before_allocation?: Maybe<Allocator_Before_Allocation_Mutation_Response>
+  delete_allocator_before_allocation_by_pk?: Maybe<Allocator_Before_Allocation>
   delete_lockup_lockedup?: Maybe<Lockup_Lockedup_Mutation_Response>
+  delete_lockup_lockedup_by_pk?: Maybe<Lockup_Lockedup>
   delete_market_factory_create?: Maybe<Market_Factory_Create_Mutation_Response>
+  delete_market_factory_create_by_pk?: Maybe<Market_Factory_Create>
   delete_metrics_factory_create?: Maybe<Metrics_Factory_Create_Mutation_Response>
+  delete_metrics_factory_create_by_pk?: Maybe<Metrics_Factory_Create>
   delete_metrics_factory_destroy?: Maybe<Metrics_Factory_Destroy_Mutation_Response>
+  delete_metrics_factory_destroy_by_pk?: Maybe<Metrics_Factory_Destroy>
   delete_policy_factory_create?: Maybe<Policy_Factory_Create_Mutation_Response>
+  delete_policy_factory_create_by_pk?: Maybe<Policy_Factory_Create>
   delete_property_authentication?: Maybe<Property_Authentication_Mutation_Response>
+  delete_property_authentication_by_pk?: Maybe<Property_Authentication>
   delete_property_authentication_deleted?: Maybe<Property_Authentication_Deleted_Mutation_Response>
+  delete_property_authentication_deleted_by_pk?: Maybe<Property_Authentication_Deleted>
   delete_property_factory_create?: Maybe<Property_Factory_Create_Mutation_Response>
+  delete_property_factory_create_by_pk?: Maybe<Property_Factory_Create>
   delete_reward_calculation_result?: Maybe<Reward_Calculation_Result_Mutation_Response>
+  delete_reward_calculation_result_by_pk?: Maybe<Reward_Calculation_Result>
   insert_allocator_allocation_result?: Maybe<Allocator_Allocation_Result_Mutation_Response>
+  insert_allocator_allocation_result_one?: Maybe<Allocator_Allocation_Result>
   insert_allocator_before_allocation?: Maybe<Allocator_Before_Allocation_Mutation_Response>
+  insert_allocator_before_allocation_one?: Maybe<Allocator_Before_Allocation>
   insert_lockup_lockedup?: Maybe<Lockup_Lockedup_Mutation_Response>
+  insert_lockup_lockedup_one?: Maybe<Lockup_Lockedup>
   insert_market_factory_create?: Maybe<Market_Factory_Create_Mutation_Response>
+  insert_market_factory_create_one?: Maybe<Market_Factory_Create>
   insert_metrics_factory_create?: Maybe<Metrics_Factory_Create_Mutation_Response>
+  insert_metrics_factory_create_one?: Maybe<Metrics_Factory_Create>
   insert_metrics_factory_destroy?: Maybe<Metrics_Factory_Destroy_Mutation_Response>
+  insert_metrics_factory_destroy_one?: Maybe<Metrics_Factory_Destroy>
   insert_policy_factory_create?: Maybe<Policy_Factory_Create_Mutation_Response>
+  insert_policy_factory_create_one?: Maybe<Policy_Factory_Create>
   insert_property_authentication?: Maybe<Property_Authentication_Mutation_Response>
   insert_property_authentication_deleted?: Maybe<Property_Authentication_Deleted_Mutation_Response>
+  insert_property_authentication_deleted_one?: Maybe<Property_Authentication_Deleted>
+  insert_property_authentication_one?: Maybe<Property_Authentication>
   insert_property_factory_create?: Maybe<Property_Factory_Create_Mutation_Response>
+  insert_property_factory_create_one?: Maybe<Property_Factory_Create>
   insert_reward_calculation_result?: Maybe<Reward_Calculation_Result_Mutation_Response>
+  insert_reward_calculation_result_one?: Maybe<Reward_Calculation_Result>
   update_allocator_allocation_result?: Maybe<Allocator_Allocation_Result_Mutation_Response>
+  update_allocator_allocation_result_by_pk?: Maybe<Allocator_Allocation_Result>
   update_allocator_before_allocation?: Maybe<Allocator_Before_Allocation_Mutation_Response>
+  update_allocator_before_allocation_by_pk?: Maybe<Allocator_Before_Allocation>
   update_lockup_lockedup?: Maybe<Lockup_Lockedup_Mutation_Response>
+  update_lockup_lockedup_by_pk?: Maybe<Lockup_Lockedup>
   update_market_factory_create?: Maybe<Market_Factory_Create_Mutation_Response>
+  update_market_factory_create_by_pk?: Maybe<Market_Factory_Create>
   update_metrics_factory_create?: Maybe<Metrics_Factory_Create_Mutation_Response>
+  update_metrics_factory_create_by_pk?: Maybe<Metrics_Factory_Create>
   update_metrics_factory_destroy?: Maybe<Metrics_Factory_Destroy_Mutation_Response>
+  update_metrics_factory_destroy_by_pk?: Maybe<Metrics_Factory_Destroy>
   update_policy_factory_create?: Maybe<Policy_Factory_Create_Mutation_Response>
+  update_policy_factory_create_by_pk?: Maybe<Policy_Factory_Create>
   update_property_authentication?: Maybe<Property_Authentication_Mutation_Response>
+  update_property_authentication_by_pk?: Maybe<Property_Authentication>
   update_property_authentication_deleted?: Maybe<Property_Authentication_Deleted_Mutation_Response>
+  update_property_authentication_deleted_by_pk?: Maybe<Property_Authentication_Deleted>
   update_property_factory_create?: Maybe<Property_Factory_Create_Mutation_Response>
+  update_property_factory_create_by_pk?: Maybe<Property_Factory_Create>
   update_reward_calculation_result?: Maybe<Reward_Calculation_Result_Mutation_Response>
+  update_reward_calculation_result_by_pk?: Maybe<Reward_Calculation_Result>
 }
 
 export type Mutation_RootDelete_Allocator_Allocation_ResultArgs = {
   where: Allocator_Allocation_Result_Bool_Exp
 }
 
+export type Mutation_RootDelete_Allocator_Allocation_Result_By_PkArgs = {
+  event_id: Scalars['String']
+}
+
 export type Mutation_RootDelete_Allocator_Before_AllocationArgs = {
   where: Allocator_Before_Allocation_Bool_Exp
+}
+
+export type Mutation_RootDelete_Allocator_Before_Allocation_By_PkArgs = {
+  event_id: Scalars['String']
 }
 
 export type Mutation_RootDelete_Lockup_LockedupArgs = {
   where: Lockup_Lockedup_Bool_Exp
 }
 
+export type Mutation_RootDelete_Lockup_Lockedup_By_PkArgs = {
+  event_id: Scalars['String']
+}
+
 export type Mutation_RootDelete_Market_Factory_CreateArgs = {
   where: Market_Factory_Create_Bool_Exp
+}
+
+export type Mutation_RootDelete_Market_Factory_Create_By_PkArgs = {
+  event_id: Scalars['String']
 }
 
 export type Mutation_RootDelete_Metrics_Factory_CreateArgs = {
   where: Metrics_Factory_Create_Bool_Exp
 }
 
+export type Mutation_RootDelete_Metrics_Factory_Create_By_PkArgs = {
+  event_id: Scalars['String']
+}
+
 export type Mutation_RootDelete_Metrics_Factory_DestroyArgs = {
   where: Metrics_Factory_Destroy_Bool_Exp
+}
+
+export type Mutation_RootDelete_Metrics_Factory_Destroy_By_PkArgs = {
+  event_id: Scalars['String']
 }
 
 export type Mutation_RootDelete_Policy_Factory_CreateArgs = {
   where: Policy_Factory_Create_Bool_Exp
 }
 
+export type Mutation_RootDelete_Policy_Factory_Create_By_PkArgs = {
+  event_id: Scalars['String']
+}
+
 export type Mutation_RootDelete_Property_AuthenticationArgs = {
   where: Property_Authentication_Bool_Exp
+}
+
+export type Mutation_RootDelete_Property_Authentication_By_PkArgs = {
+  metrics: Scalars['String']
+  property: Scalars['String']
 }
 
 export type Mutation_RootDelete_Property_Authentication_DeletedArgs = {
   where: Property_Authentication_Deleted_Bool_Exp
 }
 
+export type Mutation_RootDelete_Property_Authentication_Deleted_By_PkArgs = {
+  metrics: Scalars['String']
+  property: Scalars['String']
+}
+
 export type Mutation_RootDelete_Property_Factory_CreateArgs = {
   where: Property_Factory_Create_Bool_Exp
+}
+
+export type Mutation_RootDelete_Property_Factory_Create_By_PkArgs = {
+  event_id: Scalars['String']
 }
 
 export type Mutation_RootDelete_Reward_Calculation_ResultArgs = {
   where: Reward_Calculation_Result_Bool_Exp
 }
 
+export type Mutation_RootDelete_Reward_Calculation_Result_By_PkArgs = {
+  alocator_allocation_result_event_id: Scalars['String']
+}
+
 export type Mutation_RootInsert_Allocator_Allocation_ResultArgs = {
   objects: Array<Allocator_Allocation_Result_Insert_Input>
+  on_conflict?: Maybe<Allocator_Allocation_Result_On_Conflict>
+}
+
+export type Mutation_RootInsert_Allocator_Allocation_Result_OneArgs = {
+  object: Allocator_Allocation_Result_Insert_Input
   on_conflict?: Maybe<Allocator_Allocation_Result_On_Conflict>
 }
 
@@ -2166,8 +2400,18 @@ export type Mutation_RootInsert_Allocator_Before_AllocationArgs = {
   on_conflict?: Maybe<Allocator_Before_Allocation_On_Conflict>
 }
 
+export type Mutation_RootInsert_Allocator_Before_Allocation_OneArgs = {
+  object: Allocator_Before_Allocation_Insert_Input
+  on_conflict?: Maybe<Allocator_Before_Allocation_On_Conflict>
+}
+
 export type Mutation_RootInsert_Lockup_LockedupArgs = {
   objects: Array<Lockup_Lockedup_Insert_Input>
+  on_conflict?: Maybe<Lockup_Lockedup_On_Conflict>
+}
+
+export type Mutation_RootInsert_Lockup_Lockedup_OneArgs = {
+  object: Lockup_Lockedup_Insert_Input
   on_conflict?: Maybe<Lockup_Lockedup_On_Conflict>
 }
 
@@ -2176,8 +2420,18 @@ export type Mutation_RootInsert_Market_Factory_CreateArgs = {
   on_conflict?: Maybe<Market_Factory_Create_On_Conflict>
 }
 
+export type Mutation_RootInsert_Market_Factory_Create_OneArgs = {
+  object: Market_Factory_Create_Insert_Input
+  on_conflict?: Maybe<Market_Factory_Create_On_Conflict>
+}
+
 export type Mutation_RootInsert_Metrics_Factory_CreateArgs = {
   objects: Array<Metrics_Factory_Create_Insert_Input>
+  on_conflict?: Maybe<Metrics_Factory_Create_On_Conflict>
+}
+
+export type Mutation_RootInsert_Metrics_Factory_Create_OneArgs = {
+  object: Metrics_Factory_Create_Insert_Input
   on_conflict?: Maybe<Metrics_Factory_Create_On_Conflict>
 }
 
@@ -2186,8 +2440,18 @@ export type Mutation_RootInsert_Metrics_Factory_DestroyArgs = {
   on_conflict?: Maybe<Metrics_Factory_Destroy_On_Conflict>
 }
 
+export type Mutation_RootInsert_Metrics_Factory_Destroy_OneArgs = {
+  object: Metrics_Factory_Destroy_Insert_Input
+  on_conflict?: Maybe<Metrics_Factory_Destroy_On_Conflict>
+}
+
 export type Mutation_RootInsert_Policy_Factory_CreateArgs = {
   objects: Array<Policy_Factory_Create_Insert_Input>
+  on_conflict?: Maybe<Policy_Factory_Create_On_Conflict>
+}
+
+export type Mutation_RootInsert_Policy_Factory_Create_OneArgs = {
+  object: Policy_Factory_Create_Insert_Input
   on_conflict?: Maybe<Policy_Factory_Create_On_Conflict>
 }
 
@@ -2201,13 +2465,33 @@ export type Mutation_RootInsert_Property_Authentication_DeletedArgs = {
   on_conflict?: Maybe<Property_Authentication_Deleted_On_Conflict>
 }
 
+export type Mutation_RootInsert_Property_Authentication_Deleted_OneArgs = {
+  object: Property_Authentication_Deleted_Insert_Input
+  on_conflict?: Maybe<Property_Authentication_Deleted_On_Conflict>
+}
+
+export type Mutation_RootInsert_Property_Authentication_OneArgs = {
+  object: Property_Authentication_Insert_Input
+  on_conflict?: Maybe<Property_Authentication_On_Conflict>
+}
+
 export type Mutation_RootInsert_Property_Factory_CreateArgs = {
   objects: Array<Property_Factory_Create_Insert_Input>
   on_conflict?: Maybe<Property_Factory_Create_On_Conflict>
 }
 
+export type Mutation_RootInsert_Property_Factory_Create_OneArgs = {
+  object: Property_Factory_Create_Insert_Input
+  on_conflict?: Maybe<Property_Factory_Create_On_Conflict>
+}
+
 export type Mutation_RootInsert_Reward_Calculation_ResultArgs = {
   objects: Array<Reward_Calculation_Result_Insert_Input>
+  on_conflict?: Maybe<Reward_Calculation_Result_On_Conflict>
+}
+
+export type Mutation_RootInsert_Reward_Calculation_Result_OneArgs = {
+  object: Reward_Calculation_Result_Insert_Input
   on_conflict?: Maybe<Reward_Calculation_Result_On_Conflict>
 }
 
@@ -2217,10 +2501,22 @@ export type Mutation_RootUpdate_Allocator_Allocation_ResultArgs = {
   where: Allocator_Allocation_Result_Bool_Exp
 }
 
+export type Mutation_RootUpdate_Allocator_Allocation_Result_By_PkArgs = {
+  _inc?: Maybe<Allocator_Allocation_Result_Inc_Input>
+  _set?: Maybe<Allocator_Allocation_Result_Set_Input>
+  pk_columns: Allocator_Allocation_Result_Pk_Columns_Input
+}
+
 export type Mutation_RootUpdate_Allocator_Before_AllocationArgs = {
   _inc?: Maybe<Allocator_Before_Allocation_Inc_Input>
   _set?: Maybe<Allocator_Before_Allocation_Set_Input>
   where: Allocator_Before_Allocation_Bool_Exp
+}
+
+export type Mutation_RootUpdate_Allocator_Before_Allocation_By_PkArgs = {
+  _inc?: Maybe<Allocator_Before_Allocation_Inc_Input>
+  _set?: Maybe<Allocator_Before_Allocation_Set_Input>
+  pk_columns: Allocator_Before_Allocation_Pk_Columns_Input
 }
 
 export type Mutation_RootUpdate_Lockup_LockedupArgs = {
@@ -2229,10 +2525,22 @@ export type Mutation_RootUpdate_Lockup_LockedupArgs = {
   where: Lockup_Lockedup_Bool_Exp
 }
 
+export type Mutation_RootUpdate_Lockup_Lockedup_By_PkArgs = {
+  _inc?: Maybe<Lockup_Lockedup_Inc_Input>
+  _set?: Maybe<Lockup_Lockedup_Set_Input>
+  pk_columns: Lockup_Lockedup_Pk_Columns_Input
+}
+
 export type Mutation_RootUpdate_Market_Factory_CreateArgs = {
   _inc?: Maybe<Market_Factory_Create_Inc_Input>
   _set?: Maybe<Market_Factory_Create_Set_Input>
   where: Market_Factory_Create_Bool_Exp
+}
+
+export type Mutation_RootUpdate_Market_Factory_Create_By_PkArgs = {
+  _inc?: Maybe<Market_Factory_Create_Inc_Input>
+  _set?: Maybe<Market_Factory_Create_Set_Input>
+  pk_columns: Market_Factory_Create_Pk_Columns_Input
 }
 
 export type Mutation_RootUpdate_Metrics_Factory_CreateArgs = {
@@ -2241,10 +2549,22 @@ export type Mutation_RootUpdate_Metrics_Factory_CreateArgs = {
   where: Metrics_Factory_Create_Bool_Exp
 }
 
+export type Mutation_RootUpdate_Metrics_Factory_Create_By_PkArgs = {
+  _inc?: Maybe<Metrics_Factory_Create_Inc_Input>
+  _set?: Maybe<Metrics_Factory_Create_Set_Input>
+  pk_columns: Metrics_Factory_Create_Pk_Columns_Input
+}
+
 export type Mutation_RootUpdate_Metrics_Factory_DestroyArgs = {
   _inc?: Maybe<Metrics_Factory_Destroy_Inc_Input>
   _set?: Maybe<Metrics_Factory_Destroy_Set_Input>
   where: Metrics_Factory_Destroy_Bool_Exp
+}
+
+export type Mutation_RootUpdate_Metrics_Factory_Destroy_By_PkArgs = {
+  _inc?: Maybe<Metrics_Factory_Destroy_Inc_Input>
+  _set?: Maybe<Metrics_Factory_Destroy_Set_Input>
+  pk_columns: Metrics_Factory_Destroy_Pk_Columns_Input
 }
 
 export type Mutation_RootUpdate_Policy_Factory_CreateArgs = {
@@ -2253,10 +2573,22 @@ export type Mutation_RootUpdate_Policy_Factory_CreateArgs = {
   where: Policy_Factory_Create_Bool_Exp
 }
 
+export type Mutation_RootUpdate_Policy_Factory_Create_By_PkArgs = {
+  _inc?: Maybe<Policy_Factory_Create_Inc_Input>
+  _set?: Maybe<Policy_Factory_Create_Set_Input>
+  pk_columns: Policy_Factory_Create_Pk_Columns_Input
+}
+
 export type Mutation_RootUpdate_Property_AuthenticationArgs = {
   _inc?: Maybe<Property_Authentication_Inc_Input>
   _set?: Maybe<Property_Authentication_Set_Input>
   where: Property_Authentication_Bool_Exp
+}
+
+export type Mutation_RootUpdate_Property_Authentication_By_PkArgs = {
+  _inc?: Maybe<Property_Authentication_Inc_Input>
+  _set?: Maybe<Property_Authentication_Set_Input>
+  pk_columns: Property_Authentication_Pk_Columns_Input
 }
 
 export type Mutation_RootUpdate_Property_Authentication_DeletedArgs = {
@@ -2265,16 +2597,34 @@ export type Mutation_RootUpdate_Property_Authentication_DeletedArgs = {
   where: Property_Authentication_Deleted_Bool_Exp
 }
 
+export type Mutation_RootUpdate_Property_Authentication_Deleted_By_PkArgs = {
+  _inc?: Maybe<Property_Authentication_Deleted_Inc_Input>
+  _set?: Maybe<Property_Authentication_Deleted_Set_Input>
+  pk_columns: Property_Authentication_Deleted_Pk_Columns_Input
+}
+
 export type Mutation_RootUpdate_Property_Factory_CreateArgs = {
   _inc?: Maybe<Property_Factory_Create_Inc_Input>
   _set?: Maybe<Property_Factory_Create_Set_Input>
   where: Property_Factory_Create_Bool_Exp
 }
 
+export type Mutation_RootUpdate_Property_Factory_Create_By_PkArgs = {
+  _inc?: Maybe<Property_Factory_Create_Inc_Input>
+  _set?: Maybe<Property_Factory_Create_Set_Input>
+  pk_columns: Property_Factory_Create_Pk_Columns_Input
+}
+
 export type Mutation_RootUpdate_Reward_Calculation_ResultArgs = {
   _inc?: Maybe<Reward_Calculation_Result_Inc_Input>
   _set?: Maybe<Reward_Calculation_Result_Set_Input>
   where: Reward_Calculation_Result_Bool_Exp
+}
+
+export type Mutation_RootUpdate_Reward_Calculation_Result_By_PkArgs = {
+  _inc?: Maybe<Reward_Calculation_Result_Inc_Input>
+  _set?: Maybe<Reward_Calculation_Result_Set_Input>
+  pk_columns: Reward_Calculation_Result_Pk_Columns_Input
 }
 
 export type Numeric_Comparison_Exp = {
@@ -3202,8 +3552,26 @@ export type Policy_Factory_Create = {
   inner_policy: Scalars['String']
   log_index: Scalars['Int']
   policy_address: Scalars['String']
+  policy_n_reward: Array<Reward_Calculation_Result>
+  policy_n_reward_aggregate: Reward_Calculation_Result_Aggregate
   raw_data: Scalars['String']
   transaction_index: Scalars['Int']
+}
+
+export type Policy_Factory_CreatePolicy_N_RewardArgs = {
+  distinct_on?: Maybe<Array<Reward_Calculation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Reward_Calculation_Result_Order_By>>
+  where?: Maybe<Reward_Calculation_Result_Bool_Exp>
+}
+
+export type Policy_Factory_CreatePolicy_N_Reward_AggregateArgs = {
+  distinct_on?: Maybe<Array<Reward_Calculation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Reward_Calculation_Result_Order_By>>
+  where?: Maybe<Reward_Calculation_Result_Bool_Exp>
 }
 
 export type Policy_Factory_Create_Aggregate = {
@@ -3274,6 +3642,7 @@ export type Policy_Factory_Create_Bool_Exp = {
   inner_policy?: Maybe<String_Comparison_Exp>
   log_index?: Maybe<Int_Comparison_Exp>
   policy_address?: Maybe<String_Comparison_Exp>
+  policy_n_reward?: Maybe<Reward_Calculation_Result_Bool_Exp>
   raw_data?: Maybe<String_Comparison_Exp>
   transaction_index?: Maybe<Int_Comparison_Exp>
 }
@@ -3295,6 +3664,7 @@ export type Policy_Factory_Create_Insert_Input = {
   inner_policy?: Maybe<Scalars['String']>
   log_index?: Maybe<Scalars['Int']>
   policy_address?: Maybe<Scalars['String']>
+  policy_n_reward?: Maybe<Reward_Calculation_Result_Arr_Rel_Insert_Input>
   raw_data?: Maybe<Scalars['String']>
   transaction_index?: Maybe<Scalars['Int']>
 }
@@ -3369,8 +3739,13 @@ export type Policy_Factory_Create_Order_By = {
   inner_policy?: Maybe<Order_By>
   log_index?: Maybe<Order_By>
   policy_address?: Maybe<Order_By>
+  policy_n_reward_aggregate?: Maybe<Reward_Calculation_Result_Aggregate_Order_By>
   raw_data?: Maybe<Order_By>
   transaction_index?: Maybe<Order_By>
+}
+
+export type Policy_Factory_Create_Pk_Columns_Input = {
+  event_id: Scalars['String']
 }
 
 export enum Policy_Factory_Create_Select_Column {
@@ -3500,10 +3875,48 @@ export type Policy_Factory_Create_Variance_Order_By = {
 export type Property_Authentication = {
   __typename?: 'property_authentication'
   authentication_id: Scalars['String']
+  authentication_n_allocation: Array<Allocator_Allocation_Result>
+  authentication_n_allocation_aggregate: Allocator_Allocation_Result_Aggregate
+  authentication_n_market?: Maybe<Market_Factory_Create>
+  authentication_n_property?: Maybe<Property_Factory_Create>
+  authentication_n_reward: Array<Reward_Calculation_Result>
+  authentication_n_reward_aggregate: Reward_Calculation_Result_Aggregate
   block_number: Scalars['Int']
   market: Scalars['String']
   metrics: Scalars['String']
   property: Scalars['String']
+}
+
+export type Property_AuthenticationAuthentication_N_AllocationArgs = {
+  distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Allocator_Allocation_Result_Order_By>>
+  where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+}
+
+export type Property_AuthenticationAuthentication_N_Allocation_AggregateArgs = {
+  distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Allocator_Allocation_Result_Order_By>>
+  where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+}
+
+export type Property_AuthenticationAuthentication_N_RewardArgs = {
+  distinct_on?: Maybe<Array<Reward_Calculation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Reward_Calculation_Result_Order_By>>
+  where?: Maybe<Reward_Calculation_Result_Bool_Exp>
+}
+
+export type Property_AuthenticationAuthentication_N_Reward_AggregateArgs = {
+  distinct_on?: Maybe<Array<Reward_Calculation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Reward_Calculation_Result_Order_By>>
+  where?: Maybe<Reward_Calculation_Result_Bool_Exp>
 }
 
 export type Property_Authentication_Aggregate = {
@@ -3565,6 +3978,10 @@ export type Property_Authentication_Bool_Exp = {
   _not?: Maybe<Property_Authentication_Bool_Exp>
   _or?: Maybe<Array<Maybe<Property_Authentication_Bool_Exp>>>
   authentication_id?: Maybe<String_Comparison_Exp>
+  authentication_n_allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+  authentication_n_market?: Maybe<Market_Factory_Create_Bool_Exp>
+  authentication_n_property?: Maybe<Property_Factory_Create_Bool_Exp>
+  authentication_n_reward?: Maybe<Reward_Calculation_Result_Bool_Exp>
   block_number?: Maybe<Int_Comparison_Exp>
   market?: Maybe<String_Comparison_Exp>
   metrics?: Maybe<String_Comparison_Exp>
@@ -3577,11 +3994,49 @@ export enum Property_Authentication_Constraint {
 
 export type Property_Authentication_Deleted = {
   __typename?: 'property_authentication_deleted'
+  authentication_deleted_n_allocation: Array<Allocator_Allocation_Result>
+  authentication_deleted_n_allocation_aggregate: Allocator_Allocation_Result_Aggregate
+  authentication_deleted_n_market?: Maybe<Market_Factory_Create>
+  authentication_deleted_n_property?: Maybe<Property_Factory_Create>
+  authentication_deleted_n_reward: Array<Reward_Calculation_Result>
+  authentication_deleted_n_reward_aggregate: Reward_Calculation_Result_Aggregate
   authentication_id: Scalars['String']
   block_number: Scalars['Int']
   market: Scalars['String']
   metrics: Scalars['String']
   property: Scalars['String']
+}
+
+export type Property_Authentication_DeletedAuthentication_Deleted_N_AllocationArgs = {
+  distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Allocator_Allocation_Result_Order_By>>
+  where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+}
+
+export type Property_Authentication_DeletedAuthentication_Deleted_N_Allocation_AggregateArgs = {
+  distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Allocator_Allocation_Result_Order_By>>
+  where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+}
+
+export type Property_Authentication_DeletedAuthentication_Deleted_N_RewardArgs = {
+  distinct_on?: Maybe<Array<Reward_Calculation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Reward_Calculation_Result_Order_By>>
+  where?: Maybe<Reward_Calculation_Result_Bool_Exp>
+}
+
+export type Property_Authentication_DeletedAuthentication_Deleted_N_Reward_AggregateArgs = {
+  distinct_on?: Maybe<Array<Reward_Calculation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Reward_Calculation_Result_Order_By>>
+  where?: Maybe<Reward_Calculation_Result_Bool_Exp>
 }
 
 export type Property_Authentication_Deleted_Aggregate = {
@@ -3642,6 +4097,10 @@ export type Property_Authentication_Deleted_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Property_Authentication_Deleted_Bool_Exp>>>
   _not?: Maybe<Property_Authentication_Deleted_Bool_Exp>
   _or?: Maybe<Array<Maybe<Property_Authentication_Deleted_Bool_Exp>>>
+  authentication_deleted_n_allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+  authentication_deleted_n_market?: Maybe<Market_Factory_Create_Bool_Exp>
+  authentication_deleted_n_property?: Maybe<Property_Factory_Create_Bool_Exp>
+  authentication_deleted_n_reward?: Maybe<Reward_Calculation_Result_Bool_Exp>
   authentication_id?: Maybe<String_Comparison_Exp>
   block_number?: Maybe<Int_Comparison_Exp>
   market?: Maybe<String_Comparison_Exp>
@@ -3658,6 +4117,10 @@ export type Property_Authentication_Deleted_Inc_Input = {
 }
 
 export type Property_Authentication_Deleted_Insert_Input = {
+  authentication_deleted_n_allocation?: Maybe<Allocator_Allocation_Result_Arr_Rel_Insert_Input>
+  authentication_deleted_n_market?: Maybe<Market_Factory_Create_Obj_Rel_Insert_Input>
+  authentication_deleted_n_property?: Maybe<Property_Factory_Create_Obj_Rel_Insert_Input>
+  authentication_deleted_n_reward?: Maybe<Reward_Calculation_Result_Arr_Rel_Insert_Input>
   authentication_id?: Maybe<Scalars['String']>
   block_number?: Maybe<Scalars['Int']>
   market?: Maybe<Scalars['String']>
@@ -3717,11 +4180,20 @@ export type Property_Authentication_Deleted_On_Conflict = {
 }
 
 export type Property_Authentication_Deleted_Order_By = {
+  authentication_deleted_n_allocation_aggregate?: Maybe<Allocator_Allocation_Result_Aggregate_Order_By>
+  authentication_deleted_n_market?: Maybe<Market_Factory_Create_Order_By>
+  authentication_deleted_n_property?: Maybe<Property_Factory_Create_Order_By>
+  authentication_deleted_n_reward_aggregate?: Maybe<Reward_Calculation_Result_Aggregate_Order_By>
   authentication_id?: Maybe<Order_By>
   block_number?: Maybe<Order_By>
   market?: Maybe<Order_By>
   metrics?: Maybe<Order_By>
   property?: Maybe<Order_By>
+}
+
+export type Property_Authentication_Deleted_Pk_Columns_Input = {
+  metrics: Scalars['String']
+  property: Scalars['String']
 }
 
 export enum Property_Authentication_Deleted_Select_Column {
@@ -3817,6 +4289,10 @@ export type Property_Authentication_Inc_Input = {
 
 export type Property_Authentication_Insert_Input = {
   authentication_id?: Maybe<Scalars['String']>
+  authentication_n_allocation?: Maybe<Allocator_Allocation_Result_Arr_Rel_Insert_Input>
+  authentication_n_market?: Maybe<Market_Factory_Create_Obj_Rel_Insert_Input>
+  authentication_n_property?: Maybe<Property_Factory_Create_Obj_Rel_Insert_Input>
+  authentication_n_reward?: Maybe<Reward_Calculation_Result_Arr_Rel_Insert_Input>
   block_number?: Maybe<Scalars['Int']>
   market?: Maybe<Scalars['String']>
   metrics?: Maybe<Scalars['String']>
@@ -3876,10 +4352,19 @@ export type Property_Authentication_On_Conflict = {
 
 export type Property_Authentication_Order_By = {
   authentication_id?: Maybe<Order_By>
+  authentication_n_allocation_aggregate?: Maybe<Allocator_Allocation_Result_Aggregate_Order_By>
+  authentication_n_market?: Maybe<Market_Factory_Create_Order_By>
+  authentication_n_property?: Maybe<Property_Factory_Create_Order_By>
+  authentication_n_reward_aggregate?: Maybe<Reward_Calculation_Result_Aggregate_Order_By>
   block_number?: Maybe<Order_By>
   market?: Maybe<Order_By>
   metrics?: Maybe<Order_By>
   property?: Maybe<Order_By>
+}
+
+export type Property_Authentication_Pk_Columns_Input = {
+  metrics: Scalars['String']
+  property: Scalars['String']
 }
 
 export enum Property_Authentication_Select_Column {
@@ -3976,8 +4461,80 @@ export type Property_Factory_Create = {
   from_address: Scalars['String']
   log_index: Scalars['Int']
   property: Scalars['String']
+  property_n_allocation: Array<Allocator_Allocation_Result>
+  property_n_allocation_aggregate: Allocator_Allocation_Result_Aggregate
+  property_n_authentication: Array<Property_Authentication>
+  property_n_authentication_aggregate: Property_Authentication_Aggregate
+  property_n_authentication_deleted: Array<Property_Authentication_Deleted>
+  property_n_authentication_deleted_aggregate: Property_Authentication_Deleted_Aggregate
+  property_n_lockup: Array<Lockup_Lockedup>
+  property_n_lockup_aggregate: Lockup_Lockedup_Aggregate
   raw_data: Scalars['String']
   transaction_index: Scalars['Int']
+}
+
+export type Property_Factory_CreateProperty_N_AllocationArgs = {
+  distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Allocator_Allocation_Result_Order_By>>
+  where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+}
+
+export type Property_Factory_CreateProperty_N_Allocation_AggregateArgs = {
+  distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Allocator_Allocation_Result_Order_By>>
+  where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+}
+
+export type Property_Factory_CreateProperty_N_AuthenticationArgs = {
+  distinct_on?: Maybe<Array<Property_Authentication_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Property_Authentication_Order_By>>
+  where?: Maybe<Property_Authentication_Bool_Exp>
+}
+
+export type Property_Factory_CreateProperty_N_Authentication_AggregateArgs = {
+  distinct_on?: Maybe<Array<Property_Authentication_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Property_Authentication_Order_By>>
+  where?: Maybe<Property_Authentication_Bool_Exp>
+}
+
+export type Property_Factory_CreateProperty_N_Authentication_DeletedArgs = {
+  distinct_on?: Maybe<Array<Property_Authentication_Deleted_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Property_Authentication_Deleted_Order_By>>
+  where?: Maybe<Property_Authentication_Deleted_Bool_Exp>
+}
+
+export type Property_Factory_CreateProperty_N_Authentication_Deleted_AggregateArgs = {
+  distinct_on?: Maybe<Array<Property_Authentication_Deleted_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Property_Authentication_Deleted_Order_By>>
+  where?: Maybe<Property_Authentication_Deleted_Bool_Exp>
+}
+
+export type Property_Factory_CreateProperty_N_LockupArgs = {
+  distinct_on?: Maybe<Array<Lockup_Lockedup_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Lockup_Lockedup_Order_By>>
+  where?: Maybe<Lockup_Lockedup_Bool_Exp>
+}
+
+export type Property_Factory_CreateProperty_N_Lockup_AggregateArgs = {
+  distinct_on?: Maybe<Array<Lockup_Lockedup_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Lockup_Lockedup_Order_By>>
+  where?: Maybe<Lockup_Lockedup_Bool_Exp>
 }
 
 export type Property_Factory_Create_Aggregate = {
@@ -4047,6 +4604,10 @@ export type Property_Factory_Create_Bool_Exp = {
   from_address?: Maybe<String_Comparison_Exp>
   log_index?: Maybe<Int_Comparison_Exp>
   property?: Maybe<String_Comparison_Exp>
+  property_n_allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+  property_n_authentication?: Maybe<Property_Authentication_Bool_Exp>
+  property_n_authentication_deleted?: Maybe<Property_Authentication_Deleted_Bool_Exp>
+  property_n_lockup?: Maybe<Lockup_Lockedup_Bool_Exp>
   raw_data?: Maybe<String_Comparison_Exp>
   transaction_index?: Maybe<Int_Comparison_Exp>
 }
@@ -4067,6 +4628,10 @@ export type Property_Factory_Create_Insert_Input = {
   from_address?: Maybe<Scalars['String']>
   log_index?: Maybe<Scalars['Int']>
   property?: Maybe<Scalars['String']>
+  property_n_allocation?: Maybe<Allocator_Allocation_Result_Arr_Rel_Insert_Input>
+  property_n_authentication?: Maybe<Property_Authentication_Arr_Rel_Insert_Input>
+  property_n_authentication_deleted?: Maybe<Property_Authentication_Deleted_Arr_Rel_Insert_Input>
+  property_n_lockup?: Maybe<Lockup_Lockedup_Arr_Rel_Insert_Input>
   raw_data?: Maybe<Scalars['String']>
   transaction_index?: Maybe<Scalars['Int']>
 }
@@ -4136,8 +4701,16 @@ export type Property_Factory_Create_Order_By = {
   from_address?: Maybe<Order_By>
   log_index?: Maybe<Order_By>
   property?: Maybe<Order_By>
+  property_n_allocation_aggregate?: Maybe<Allocator_Allocation_Result_Aggregate_Order_By>
+  property_n_authentication_aggregate?: Maybe<Property_Authentication_Aggregate_Order_By>
+  property_n_authentication_deleted_aggregate?: Maybe<Property_Authentication_Deleted_Aggregate_Order_By>
+  property_n_lockup_aggregate?: Maybe<Lockup_Lockedup_Aggregate_Order_By>
   raw_data?: Maybe<Order_By>
   transaction_index?: Maybe<Order_By>
+}
+
+export type Property_Factory_Create_Pk_Columns_Input = {
+  event_id: Scalars['String']
 }
 
 export enum Property_Factory_Create_Select_Column {
@@ -4565,6 +5138,10 @@ export type Reward_Calculation_Result = {
   lockup: Scalars['numeric']
   metrics: Scalars['String']
   policy: Scalars['String']
+  reward_n_allocation?: Maybe<Allocator_Allocation_Result>
+  reward_n_authentication?: Maybe<Property_Authentication>
+  reward_n_metrics?: Maybe<Metrics_Factory_Create>
+  reward_n_policy?: Maybe<Policy_Factory_Create>
   staking_reward: Scalars['numeric']
 }
 
@@ -4641,6 +5218,10 @@ export type Reward_Calculation_Result_Bool_Exp = {
   lockup?: Maybe<Numeric_Comparison_Exp>
   metrics?: Maybe<String_Comparison_Exp>
   policy?: Maybe<String_Comparison_Exp>
+  reward_n_allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+  reward_n_authentication?: Maybe<Property_Authentication_Bool_Exp>
+  reward_n_metrics?: Maybe<Metrics_Factory_Create_Bool_Exp>
+  reward_n_policy?: Maybe<Policy_Factory_Create_Bool_Exp>
   staking_reward?: Maybe<Numeric_Comparison_Exp>
 }
 
@@ -4649,7 +5230,11 @@ export enum Reward_Calculation_Result_Constraint {
 }
 
 export type Reward_Calculation_Result_Inc_Input = {
+  allocate_result?: Maybe<Scalars['numeric']>
   block_number?: Maybe<Scalars['Int']>
+  holder_reward?: Maybe<Scalars['numeric']>
+  lockup?: Maybe<Scalars['numeric']>
+  staking_reward?: Maybe<Scalars['numeric']>
 }
 
 export type Reward_Calculation_Result_Insert_Input = {
@@ -4660,6 +5245,10 @@ export type Reward_Calculation_Result_Insert_Input = {
   lockup?: Maybe<Scalars['numeric']>
   metrics?: Maybe<Scalars['String']>
   policy?: Maybe<Scalars['String']>
+  reward_n_allocation?: Maybe<Allocator_Allocation_Result_Obj_Rel_Insert_Input>
+  reward_n_authentication?: Maybe<Property_Authentication_Obj_Rel_Insert_Input>
+  reward_n_metrics?: Maybe<Metrics_Factory_Create_Obj_Rel_Insert_Input>
+  reward_n_policy?: Maybe<Policy_Factory_Create_Obj_Rel_Insert_Input>
   staking_reward?: Maybe<Scalars['numeric']>
 }
 
@@ -4734,7 +5323,15 @@ export type Reward_Calculation_Result_Order_By = {
   lockup?: Maybe<Order_By>
   metrics?: Maybe<Order_By>
   policy?: Maybe<Order_By>
+  reward_n_allocation?: Maybe<Allocator_Allocation_Result_Order_By>
+  reward_n_authentication?: Maybe<Property_Authentication_Order_By>
+  reward_n_metrics?: Maybe<Metrics_Factory_Create_Order_By>
+  reward_n_policy?: Maybe<Policy_Factory_Create_Order_By>
   staking_reward?: Maybe<Order_By>
+}
+
+export type Reward_Calculation_Result_Pk_Columns_Input = {
+  alocator_allocation_result_event_id: Scalars['String']
 }
 
 export enum Reward_Calculation_Result_Select_Column {

--- a/packages/graphql/src/react-apollo/generated.tsx
+++ b/packages/graphql/src/react-apollo/generated.tsx
@@ -18,10 +18,8 @@ export type Scalars = {
 
 export type Allocator_Allocation_Result = {
   __typename?: 'allocator_allocation_result'
-  allocation_n_authentication?: Maybe<Property_Authentication>
-  allocation_n_property?: Maybe<Property_Factory_Create>
-  allocation_n_reward?: Maybe<Reward_Calculation_Result>
   arg_value: Scalars['numeric']
+  authentication?: Maybe<Property_Authentication>
   block_number: Scalars['Int']
   event_id: Scalars['String']
   lockup_value: Scalars['numeric']
@@ -29,8 +27,10 @@ export type Allocator_Allocation_Result = {
   market: Scalars['String']
   metrics: Scalars['String']
   property: Scalars['String']
+  property_creation?: Maybe<Property_Factory_Create>
   raw_data: Scalars['String']
   result: Scalars['numeric']
+  reward?: Maybe<Reward_Calculation_Result>
   transaction_index: Scalars['Int']
 }
 
@@ -102,10 +102,8 @@ export type Allocator_Allocation_Result_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Allocator_Allocation_Result_Bool_Exp>>>
   _not?: Maybe<Allocator_Allocation_Result_Bool_Exp>
   _or?: Maybe<Array<Maybe<Allocator_Allocation_Result_Bool_Exp>>>
-  allocation_n_authentication?: Maybe<Property_Authentication_Bool_Exp>
-  allocation_n_property?: Maybe<Property_Factory_Create_Bool_Exp>
-  allocation_n_reward?: Maybe<Reward_Calculation_Result_Bool_Exp>
   arg_value?: Maybe<Numeric_Comparison_Exp>
+  authentication?: Maybe<Property_Authentication_Bool_Exp>
   block_number?: Maybe<Int_Comparison_Exp>
   event_id?: Maybe<String_Comparison_Exp>
   lockup_value?: Maybe<Numeric_Comparison_Exp>
@@ -113,8 +111,10 @@ export type Allocator_Allocation_Result_Bool_Exp = {
   market?: Maybe<String_Comparison_Exp>
   metrics?: Maybe<String_Comparison_Exp>
   property?: Maybe<String_Comparison_Exp>
+  property_creation?: Maybe<Property_Factory_Create_Bool_Exp>
   raw_data?: Maybe<String_Comparison_Exp>
   result?: Maybe<Numeric_Comparison_Exp>
+  reward?: Maybe<Reward_Calculation_Result_Bool_Exp>
   transaction_index?: Maybe<Int_Comparison_Exp>
 }
 
@@ -132,10 +132,8 @@ export type Allocator_Allocation_Result_Inc_Input = {
 }
 
 export type Allocator_Allocation_Result_Insert_Input = {
-  allocation_n_authentication?: Maybe<Property_Authentication_Obj_Rel_Insert_Input>
-  allocation_n_property?: Maybe<Property_Factory_Create_Obj_Rel_Insert_Input>
-  allocation_n_reward?: Maybe<Reward_Calculation_Result_Obj_Rel_Insert_Input>
   arg_value?: Maybe<Scalars['numeric']>
+  authentication?: Maybe<Property_Authentication_Obj_Rel_Insert_Input>
   block_number?: Maybe<Scalars['Int']>
   event_id?: Maybe<Scalars['String']>
   lockup_value?: Maybe<Scalars['numeric']>
@@ -143,8 +141,10 @@ export type Allocator_Allocation_Result_Insert_Input = {
   market?: Maybe<Scalars['String']>
   metrics?: Maybe<Scalars['String']>
   property?: Maybe<Scalars['String']>
+  property_creation?: Maybe<Property_Factory_Create_Obj_Rel_Insert_Input>
   raw_data?: Maybe<Scalars['String']>
   result?: Maybe<Scalars['numeric']>
+  reward?: Maybe<Reward_Calculation_Result_Obj_Rel_Insert_Input>
   transaction_index?: Maybe<Scalars['Int']>
 }
 
@@ -224,10 +224,8 @@ export type Allocator_Allocation_Result_On_Conflict = {
 }
 
 export type Allocator_Allocation_Result_Order_By = {
-  allocation_n_authentication?: Maybe<Property_Authentication_Order_By>
-  allocation_n_property?: Maybe<Property_Factory_Create_Order_By>
-  allocation_n_reward?: Maybe<Reward_Calculation_Result_Order_By>
   arg_value?: Maybe<Order_By>
+  authentication?: Maybe<Property_Authentication_Order_By>
   block_number?: Maybe<Order_By>
   event_id?: Maybe<Order_By>
   lockup_value?: Maybe<Order_By>
@@ -235,8 +233,10 @@ export type Allocator_Allocation_Result_Order_By = {
   market?: Maybe<Order_By>
   metrics?: Maybe<Order_By>
   property?: Maybe<Order_By>
+  property_creation?: Maybe<Property_Factory_Create_Order_By>
   raw_data?: Maybe<Order_By>
   result?: Maybe<Order_By>
+  reward?: Maybe<Reward_Calculation_Result_Order_By>
   transaction_index?: Maybe<Order_By>
 }
 
@@ -911,20 +911,20 @@ export type Int_Comparison_Exp = {
 
 export type Lockup_Lockedup = {
   __typename?: 'lockup_lockedup'
+  allocation: Array<Allocator_Allocation_Result>
+  allocation_aggregate: Allocator_Allocation_Result_Aggregate
   block_number: Scalars['Int']
   event_id: Scalars['String']
   from_address: Scalars['String']
-  lockup_n_allocation: Array<Allocator_Allocation_Result>
-  lockup_n_allocation_aggregate: Allocator_Allocation_Result_Aggregate
-  lockup_n_property?: Maybe<Property_Factory_Create>
   log_index: Scalars['Int']
   property: Scalars['String']
+  property_creation?: Maybe<Property_Factory_Create>
   raw_data: Scalars['String']
   token_value: Scalars['numeric']
   transaction_index: Scalars['Int']
 }
 
-export type Lockup_LockedupLockup_N_AllocationArgs = {
+export type Lockup_LockedupAllocationArgs = {
   distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -932,7 +932,7 @@ export type Lockup_LockedupLockup_N_AllocationArgs = {
   where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
 }
 
-export type Lockup_LockedupLockup_N_Allocation_AggregateArgs = {
+export type Lockup_LockedupAllocation_AggregateArgs = {
   distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -1004,13 +1004,13 @@ export type Lockup_Lockedup_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Lockup_Lockedup_Bool_Exp>>>
   _not?: Maybe<Lockup_Lockedup_Bool_Exp>
   _or?: Maybe<Array<Maybe<Lockup_Lockedup_Bool_Exp>>>
+  allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
   block_number?: Maybe<Int_Comparison_Exp>
   event_id?: Maybe<String_Comparison_Exp>
   from_address?: Maybe<String_Comparison_Exp>
-  lockup_n_allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
-  lockup_n_property?: Maybe<Property_Factory_Create_Bool_Exp>
   log_index?: Maybe<Int_Comparison_Exp>
   property?: Maybe<String_Comparison_Exp>
+  property_creation?: Maybe<Property_Factory_Create_Bool_Exp>
   raw_data?: Maybe<String_Comparison_Exp>
   token_value?: Maybe<Numeric_Comparison_Exp>
   transaction_index?: Maybe<Int_Comparison_Exp>
@@ -1028,13 +1028,13 @@ export type Lockup_Lockedup_Inc_Input = {
 }
 
 export type Lockup_Lockedup_Insert_Input = {
+  allocation?: Maybe<Allocator_Allocation_Result_Arr_Rel_Insert_Input>
   block_number?: Maybe<Scalars['Int']>
   event_id?: Maybe<Scalars['String']>
   from_address?: Maybe<Scalars['String']>
-  lockup_n_allocation?: Maybe<Allocator_Allocation_Result_Arr_Rel_Insert_Input>
-  lockup_n_property?: Maybe<Property_Factory_Create_Obj_Rel_Insert_Input>
   log_index?: Maybe<Scalars['Int']>
   property?: Maybe<Scalars['String']>
+  property_creation?: Maybe<Property_Factory_Create_Obj_Rel_Insert_Input>
   raw_data?: Maybe<Scalars['String']>
   token_value?: Maybe<Scalars['numeric']>
   transaction_index?: Maybe<Scalars['Int']>
@@ -1104,13 +1104,13 @@ export type Lockup_Lockedup_On_Conflict = {
 }
 
 export type Lockup_Lockedup_Order_By = {
+  allocation_aggregate?: Maybe<Allocator_Allocation_Result_Aggregate_Order_By>
   block_number?: Maybe<Order_By>
   event_id?: Maybe<Order_By>
   from_address?: Maybe<Order_By>
-  lockup_n_allocation_aggregate?: Maybe<Allocator_Allocation_Result_Aggregate_Order_By>
-  lockup_n_property?: Maybe<Property_Factory_Create_Order_By>
   log_index?: Maybe<Order_By>
   property?: Maybe<Order_By>
+  property_creation?: Maybe<Property_Factory_Create_Order_By>
   raw_data?: Maybe<Order_By>
   token_value?: Maybe<Order_By>
   transaction_index?: Maybe<Order_By>
@@ -1260,22 +1260,22 @@ export type Lockup_Lockedup_Variance_Order_By = {
 
 export type Market_Factory_Create = {
   __typename?: 'market_factory_create'
+  allocation: Array<Allocator_Allocation_Result>
+  allocation_aggregate: Allocator_Allocation_Result_Aggregate
   block_number: Scalars['Int']
+  destroyed_metrics: Array<Metrics_Factory_Destroy>
+  destroyed_metrics_aggregate: Metrics_Factory_Destroy_Aggregate
   event_id: Scalars['String']
   from_address: Scalars['String']
   log_index: Scalars['Int']
   market: Scalars['String']
-  market_n_allocation: Array<Allocator_Allocation_Result>
-  market_n_allocation_aggregate: Allocator_Allocation_Result_Aggregate
-  market_n_metrics: Array<Metrics_Factory_Create>
-  market_n_metrics_aggregate: Metrics_Factory_Create_Aggregate
-  market_n_metrics_destroy: Array<Metrics_Factory_Destroy>
-  market_n_metrics_destroy_aggregate: Metrics_Factory_Destroy_Aggregate
+  metrics: Array<Metrics_Factory_Create>
+  metrics_aggregate: Metrics_Factory_Create_Aggregate
   raw_data: Scalars['String']
   transaction_index: Scalars['Int']
 }
 
-export type Market_Factory_CreateMarket_N_AllocationArgs = {
+export type Market_Factory_CreateAllocationArgs = {
   distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -1283,7 +1283,7 @@ export type Market_Factory_CreateMarket_N_AllocationArgs = {
   where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
 }
 
-export type Market_Factory_CreateMarket_N_Allocation_AggregateArgs = {
+export type Market_Factory_CreateAllocation_AggregateArgs = {
   distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -1291,23 +1291,7 @@ export type Market_Factory_CreateMarket_N_Allocation_AggregateArgs = {
   where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
 }
 
-export type Market_Factory_CreateMarket_N_MetricsArgs = {
-  distinct_on?: Maybe<Array<Metrics_Factory_Create_Select_Column>>
-  limit?: Maybe<Scalars['Int']>
-  offset?: Maybe<Scalars['Int']>
-  order_by?: Maybe<Array<Metrics_Factory_Create_Order_By>>
-  where?: Maybe<Metrics_Factory_Create_Bool_Exp>
-}
-
-export type Market_Factory_CreateMarket_N_Metrics_AggregateArgs = {
-  distinct_on?: Maybe<Array<Metrics_Factory_Create_Select_Column>>
-  limit?: Maybe<Scalars['Int']>
-  offset?: Maybe<Scalars['Int']>
-  order_by?: Maybe<Array<Metrics_Factory_Create_Order_By>>
-  where?: Maybe<Metrics_Factory_Create_Bool_Exp>
-}
-
-export type Market_Factory_CreateMarket_N_Metrics_DestroyArgs = {
+export type Market_Factory_CreateDestroyed_MetricsArgs = {
   distinct_on?: Maybe<Array<Metrics_Factory_Destroy_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -1315,12 +1299,28 @@ export type Market_Factory_CreateMarket_N_Metrics_DestroyArgs = {
   where?: Maybe<Metrics_Factory_Destroy_Bool_Exp>
 }
 
-export type Market_Factory_CreateMarket_N_Metrics_Destroy_AggregateArgs = {
+export type Market_Factory_CreateDestroyed_Metrics_AggregateArgs = {
   distinct_on?: Maybe<Array<Metrics_Factory_Destroy_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
   order_by?: Maybe<Array<Metrics_Factory_Destroy_Order_By>>
   where?: Maybe<Metrics_Factory_Destroy_Bool_Exp>
+}
+
+export type Market_Factory_CreateMetricsArgs = {
+  distinct_on?: Maybe<Array<Metrics_Factory_Create_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Metrics_Factory_Create_Order_By>>
+  where?: Maybe<Metrics_Factory_Create_Bool_Exp>
+}
+
+export type Market_Factory_CreateMetrics_AggregateArgs = {
+  distinct_on?: Maybe<Array<Metrics_Factory_Create_Select_Column>>
+  limit?: Maybe<Scalars['Int']>
+  offset?: Maybe<Scalars['Int']>
+  order_by?: Maybe<Array<Metrics_Factory_Create_Order_By>>
+  where?: Maybe<Metrics_Factory_Create_Bool_Exp>
 }
 
 export type Market_Factory_Create_Aggregate = {
@@ -1385,14 +1385,14 @@ export type Market_Factory_Create_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Market_Factory_Create_Bool_Exp>>>
   _not?: Maybe<Market_Factory_Create_Bool_Exp>
   _or?: Maybe<Array<Maybe<Market_Factory_Create_Bool_Exp>>>
+  allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
   block_number?: Maybe<Int_Comparison_Exp>
+  destroyed_metrics?: Maybe<Metrics_Factory_Destroy_Bool_Exp>
   event_id?: Maybe<String_Comparison_Exp>
   from_address?: Maybe<String_Comparison_Exp>
   log_index?: Maybe<Int_Comparison_Exp>
   market?: Maybe<String_Comparison_Exp>
-  market_n_allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
-  market_n_metrics?: Maybe<Metrics_Factory_Create_Bool_Exp>
-  market_n_metrics_destroy?: Maybe<Metrics_Factory_Destroy_Bool_Exp>
+  metrics?: Maybe<Metrics_Factory_Create_Bool_Exp>
   raw_data?: Maybe<String_Comparison_Exp>
   transaction_index?: Maybe<Int_Comparison_Exp>
 }
@@ -1408,14 +1408,14 @@ export type Market_Factory_Create_Inc_Input = {
 }
 
 export type Market_Factory_Create_Insert_Input = {
+  allocation?: Maybe<Allocator_Allocation_Result_Arr_Rel_Insert_Input>
   block_number?: Maybe<Scalars['Int']>
+  destroyed_metrics?: Maybe<Metrics_Factory_Destroy_Arr_Rel_Insert_Input>
   event_id?: Maybe<Scalars['String']>
   from_address?: Maybe<Scalars['String']>
   log_index?: Maybe<Scalars['Int']>
   market?: Maybe<Scalars['String']>
-  market_n_allocation?: Maybe<Allocator_Allocation_Result_Arr_Rel_Insert_Input>
-  market_n_metrics?: Maybe<Metrics_Factory_Create_Arr_Rel_Insert_Input>
-  market_n_metrics_destroy?: Maybe<Metrics_Factory_Destroy_Arr_Rel_Insert_Input>
+  metrics?: Maybe<Metrics_Factory_Create_Arr_Rel_Insert_Input>
   raw_data?: Maybe<Scalars['String']>
   transaction_index?: Maybe<Scalars['Int']>
 }
@@ -1480,14 +1480,14 @@ export type Market_Factory_Create_On_Conflict = {
 }
 
 export type Market_Factory_Create_Order_By = {
+  allocation_aggregate?: Maybe<Allocator_Allocation_Result_Aggregate_Order_By>
   block_number?: Maybe<Order_By>
+  destroyed_metrics_aggregate?: Maybe<Metrics_Factory_Destroy_Aggregate_Order_By>
   event_id?: Maybe<Order_By>
   from_address?: Maybe<Order_By>
   log_index?: Maybe<Order_By>
   market?: Maybe<Order_By>
-  market_n_allocation_aggregate?: Maybe<Allocator_Allocation_Result_Aggregate_Order_By>
-  market_n_metrics_aggregate?: Maybe<Metrics_Factory_Create_Aggregate_Order_By>
-  market_n_metrics_destroy_aggregate?: Maybe<Metrics_Factory_Destroy_Aggregate_Order_By>
+  metrics_aggregate?: Maybe<Metrics_Factory_Create_Aggregate_Order_By>
   raw_data?: Maybe<Order_By>
   transaction_index?: Maybe<Order_By>
 }
@@ -1620,12 +1620,12 @@ export type Market_Factory_Create_Variance_Order_By = {
 export type Metrics_Factory_Create = {
   __typename?: 'metrics_factory_create'
   block_number: Scalars['Int']
+  destroyed_metrics?: Maybe<Metrics_Factory_Destroy>
   event_id: Scalars['String']
   from_address: Scalars['String']
   log_index: Scalars['Int']
+  market?: Maybe<Market_Factory_Create>
   metrics: Scalars['String']
-  metrics_n_market?: Maybe<Market_Factory_Create>
-  metrics_n_metrics_destroy?: Maybe<Metrics_Factory_Destroy>
   raw_data: Scalars['String']
   transaction_index: Scalars['Int']
 }
@@ -1693,12 +1693,12 @@ export type Metrics_Factory_Create_Bool_Exp = {
   _not?: Maybe<Metrics_Factory_Create_Bool_Exp>
   _or?: Maybe<Array<Maybe<Metrics_Factory_Create_Bool_Exp>>>
   block_number?: Maybe<Int_Comparison_Exp>
+  destroyed_metrics?: Maybe<Metrics_Factory_Destroy_Bool_Exp>
   event_id?: Maybe<String_Comparison_Exp>
   from_address?: Maybe<String_Comparison_Exp>
   log_index?: Maybe<Int_Comparison_Exp>
+  market?: Maybe<Market_Factory_Create_Bool_Exp>
   metrics?: Maybe<String_Comparison_Exp>
-  metrics_n_market?: Maybe<Market_Factory_Create_Bool_Exp>
-  metrics_n_metrics_destroy?: Maybe<Metrics_Factory_Destroy_Bool_Exp>
   raw_data?: Maybe<String_Comparison_Exp>
   transaction_index?: Maybe<Int_Comparison_Exp>
 }
@@ -1715,12 +1715,12 @@ export type Metrics_Factory_Create_Inc_Input = {
 
 export type Metrics_Factory_Create_Insert_Input = {
   block_number?: Maybe<Scalars['Int']>
+  destroyed_metrics?: Maybe<Metrics_Factory_Destroy_Obj_Rel_Insert_Input>
   event_id?: Maybe<Scalars['String']>
   from_address?: Maybe<Scalars['String']>
   log_index?: Maybe<Scalars['Int']>
+  market?: Maybe<Market_Factory_Create_Obj_Rel_Insert_Input>
   metrics?: Maybe<Scalars['String']>
-  metrics_n_market?: Maybe<Market_Factory_Create_Obj_Rel_Insert_Input>
-  metrics_n_metrics_destroy?: Maybe<Metrics_Factory_Destroy_Obj_Rel_Insert_Input>
   raw_data?: Maybe<Scalars['String']>
   transaction_index?: Maybe<Scalars['Int']>
 }
@@ -1786,12 +1786,12 @@ export type Metrics_Factory_Create_On_Conflict = {
 
 export type Metrics_Factory_Create_Order_By = {
   block_number?: Maybe<Order_By>
+  destroyed_metrics?: Maybe<Metrics_Factory_Destroy_Order_By>
   event_id?: Maybe<Order_By>
   from_address?: Maybe<Order_By>
   log_index?: Maybe<Order_By>
+  market?: Maybe<Market_Factory_Create_Order_By>
   metrics?: Maybe<Order_By>
-  metrics_n_market?: Maybe<Market_Factory_Create_Order_By>
-  metrics_n_metrics_destroy?: Maybe<Metrics_Factory_Destroy_Order_By>
   raw_data?: Maybe<Order_By>
   transaction_index?: Maybe<Order_By>
 }
@@ -1927,9 +1927,9 @@ export type Metrics_Factory_Destroy = {
   event_id: Scalars['String']
   from_address: Scalars['String']
   log_index: Scalars['Int']
+  market?: Maybe<Market_Factory_Create>
   metrics: Scalars['String']
-  metrics_destroy_n_market?: Maybe<Market_Factory_Create>
-  metrics_destroy_n_metrics?: Maybe<Metrics_Factory_Create>
+  metrics_creation?: Maybe<Metrics_Factory_Create>
   raw_data: Scalars['String']
   transaction_index: Scalars['Int']
 }
@@ -2000,9 +2000,9 @@ export type Metrics_Factory_Destroy_Bool_Exp = {
   event_id?: Maybe<String_Comparison_Exp>
   from_address?: Maybe<String_Comparison_Exp>
   log_index?: Maybe<Int_Comparison_Exp>
+  market?: Maybe<Market_Factory_Create_Bool_Exp>
   metrics?: Maybe<String_Comparison_Exp>
-  metrics_destroy_n_market?: Maybe<Market_Factory_Create_Bool_Exp>
-  metrics_destroy_n_metrics?: Maybe<Metrics_Factory_Create_Bool_Exp>
+  metrics_creation?: Maybe<Metrics_Factory_Create_Bool_Exp>
   raw_data?: Maybe<String_Comparison_Exp>
   transaction_index?: Maybe<Int_Comparison_Exp>
 }
@@ -2022,9 +2022,9 @@ export type Metrics_Factory_Destroy_Insert_Input = {
   event_id?: Maybe<Scalars['String']>
   from_address?: Maybe<Scalars['String']>
   log_index?: Maybe<Scalars['Int']>
+  market?: Maybe<Market_Factory_Create_Obj_Rel_Insert_Input>
   metrics?: Maybe<Scalars['String']>
-  metrics_destroy_n_market?: Maybe<Market_Factory_Create_Obj_Rel_Insert_Input>
-  metrics_destroy_n_metrics?: Maybe<Metrics_Factory_Create_Obj_Rel_Insert_Input>
+  metrics_creation?: Maybe<Metrics_Factory_Create_Obj_Rel_Insert_Input>
   raw_data?: Maybe<Scalars['String']>
   transaction_index?: Maybe<Scalars['Int']>
 }
@@ -2093,9 +2093,9 @@ export type Metrics_Factory_Destroy_Order_By = {
   event_id?: Maybe<Order_By>
   from_address?: Maybe<Order_By>
   log_index?: Maybe<Order_By>
+  market?: Maybe<Market_Factory_Create_Order_By>
   metrics?: Maybe<Order_By>
-  metrics_destroy_n_market?: Maybe<Market_Factory_Create_Order_By>
-  metrics_destroy_n_metrics?: Maybe<Metrics_Factory_Create_Order_By>
+  metrics_creation?: Maybe<Metrics_Factory_Create_Order_By>
   raw_data?: Maybe<Order_By>
   transaction_index?: Maybe<Order_By>
 }
@@ -3552,13 +3552,13 @@ export type Policy_Factory_Create = {
   inner_policy: Scalars['String']
   log_index: Scalars['Int']
   policy_address: Scalars['String']
-  policy_n_reward: Array<Reward_Calculation_Result>
-  policy_n_reward_aggregate: Reward_Calculation_Result_Aggregate
   raw_data: Scalars['String']
+  reward: Array<Reward_Calculation_Result>
+  reward_aggregate: Reward_Calculation_Result_Aggregate
   transaction_index: Scalars['Int']
 }
 
-export type Policy_Factory_CreatePolicy_N_RewardArgs = {
+export type Policy_Factory_CreateRewardArgs = {
   distinct_on?: Maybe<Array<Reward_Calculation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -3566,7 +3566,7 @@ export type Policy_Factory_CreatePolicy_N_RewardArgs = {
   where?: Maybe<Reward_Calculation_Result_Bool_Exp>
 }
 
-export type Policy_Factory_CreatePolicy_N_Reward_AggregateArgs = {
+export type Policy_Factory_CreateReward_AggregateArgs = {
   distinct_on?: Maybe<Array<Reward_Calculation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -3642,8 +3642,8 @@ export type Policy_Factory_Create_Bool_Exp = {
   inner_policy?: Maybe<String_Comparison_Exp>
   log_index?: Maybe<Int_Comparison_Exp>
   policy_address?: Maybe<String_Comparison_Exp>
-  policy_n_reward?: Maybe<Reward_Calculation_Result_Bool_Exp>
   raw_data?: Maybe<String_Comparison_Exp>
+  reward?: Maybe<Reward_Calculation_Result_Bool_Exp>
   transaction_index?: Maybe<Int_Comparison_Exp>
 }
 
@@ -3664,8 +3664,8 @@ export type Policy_Factory_Create_Insert_Input = {
   inner_policy?: Maybe<Scalars['String']>
   log_index?: Maybe<Scalars['Int']>
   policy_address?: Maybe<Scalars['String']>
-  policy_n_reward?: Maybe<Reward_Calculation_Result_Arr_Rel_Insert_Input>
   raw_data?: Maybe<Scalars['String']>
+  reward?: Maybe<Reward_Calculation_Result_Arr_Rel_Insert_Input>
   transaction_index?: Maybe<Scalars['Int']>
 }
 
@@ -3739,8 +3739,8 @@ export type Policy_Factory_Create_Order_By = {
   inner_policy?: Maybe<Order_By>
   log_index?: Maybe<Order_By>
   policy_address?: Maybe<Order_By>
-  policy_n_reward_aggregate?: Maybe<Reward_Calculation_Result_Aggregate_Order_By>
   raw_data?: Maybe<Order_By>
+  reward_aggregate?: Maybe<Reward_Calculation_Result_Aggregate_Order_By>
   transaction_index?: Maybe<Order_By>
 }
 
@@ -3874,20 +3874,20 @@ export type Policy_Factory_Create_Variance_Order_By = {
 
 export type Property_Authentication = {
   __typename?: 'property_authentication'
+  allocation: Array<Allocator_Allocation_Result>
+  allocation_aggregate: Allocator_Allocation_Result_Aggregate
   authentication_id: Scalars['String']
-  authentication_n_allocation: Array<Allocator_Allocation_Result>
-  authentication_n_allocation_aggregate: Allocator_Allocation_Result_Aggregate
-  authentication_n_market?: Maybe<Market_Factory_Create>
-  authentication_n_property?: Maybe<Property_Factory_Create>
-  authentication_n_reward: Array<Reward_Calculation_Result>
-  authentication_n_reward_aggregate: Reward_Calculation_Result_Aggregate
   block_number: Scalars['Int']
   market: Scalars['String']
+  market_creation?: Maybe<Market_Factory_Create>
   metrics: Scalars['String']
   property: Scalars['String']
+  property_creation?: Maybe<Property_Factory_Create>
+  reward: Array<Reward_Calculation_Result>
+  reward_aggregate: Reward_Calculation_Result_Aggregate
 }
 
-export type Property_AuthenticationAuthentication_N_AllocationArgs = {
+export type Property_AuthenticationAllocationArgs = {
   distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -3895,7 +3895,7 @@ export type Property_AuthenticationAuthentication_N_AllocationArgs = {
   where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
 }
 
-export type Property_AuthenticationAuthentication_N_Allocation_AggregateArgs = {
+export type Property_AuthenticationAllocation_AggregateArgs = {
   distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -3903,7 +3903,7 @@ export type Property_AuthenticationAuthentication_N_Allocation_AggregateArgs = {
   where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
 }
 
-export type Property_AuthenticationAuthentication_N_RewardArgs = {
+export type Property_AuthenticationRewardArgs = {
   distinct_on?: Maybe<Array<Reward_Calculation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -3911,7 +3911,7 @@ export type Property_AuthenticationAuthentication_N_RewardArgs = {
   where?: Maybe<Reward_Calculation_Result_Bool_Exp>
 }
 
-export type Property_AuthenticationAuthentication_N_Reward_AggregateArgs = {
+export type Property_AuthenticationReward_AggregateArgs = {
   distinct_on?: Maybe<Array<Reward_Calculation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -3977,15 +3977,15 @@ export type Property_Authentication_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Property_Authentication_Bool_Exp>>>
   _not?: Maybe<Property_Authentication_Bool_Exp>
   _or?: Maybe<Array<Maybe<Property_Authentication_Bool_Exp>>>
+  allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
   authentication_id?: Maybe<String_Comparison_Exp>
-  authentication_n_allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
-  authentication_n_market?: Maybe<Market_Factory_Create_Bool_Exp>
-  authentication_n_property?: Maybe<Property_Factory_Create_Bool_Exp>
-  authentication_n_reward?: Maybe<Reward_Calculation_Result_Bool_Exp>
   block_number?: Maybe<Int_Comparison_Exp>
   market?: Maybe<String_Comparison_Exp>
+  market_creation?: Maybe<Market_Factory_Create_Bool_Exp>
   metrics?: Maybe<String_Comparison_Exp>
   property?: Maybe<String_Comparison_Exp>
+  property_creation?: Maybe<Property_Factory_Create_Bool_Exp>
+  reward?: Maybe<Reward_Calculation_Result_Bool_Exp>
 }
 
 export enum Property_Authentication_Constraint {
@@ -3994,20 +3994,20 @@ export enum Property_Authentication_Constraint {
 
 export type Property_Authentication_Deleted = {
   __typename?: 'property_authentication_deleted'
-  authentication_deleted_n_allocation: Array<Allocator_Allocation_Result>
-  authentication_deleted_n_allocation_aggregate: Allocator_Allocation_Result_Aggregate
-  authentication_deleted_n_market?: Maybe<Market_Factory_Create>
-  authentication_deleted_n_property?: Maybe<Property_Factory_Create>
-  authentication_deleted_n_reward: Array<Reward_Calculation_Result>
-  authentication_deleted_n_reward_aggregate: Reward_Calculation_Result_Aggregate
+  allocation: Array<Allocator_Allocation_Result>
+  allocation_aggregate: Allocator_Allocation_Result_Aggregate
   authentication_id: Scalars['String']
   block_number: Scalars['Int']
   market: Scalars['String']
+  market_creation?: Maybe<Market_Factory_Create>
   metrics: Scalars['String']
   property: Scalars['String']
+  property_creation?: Maybe<Property_Factory_Create>
+  reward: Array<Reward_Calculation_Result>
+  reward_aggregate: Reward_Calculation_Result_Aggregate
 }
 
-export type Property_Authentication_DeletedAuthentication_Deleted_N_AllocationArgs = {
+export type Property_Authentication_DeletedAllocationArgs = {
   distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -4015,7 +4015,7 @@ export type Property_Authentication_DeletedAuthentication_Deleted_N_AllocationAr
   where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
 }
 
-export type Property_Authentication_DeletedAuthentication_Deleted_N_Allocation_AggregateArgs = {
+export type Property_Authentication_DeletedAllocation_AggregateArgs = {
   distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -4023,7 +4023,7 @@ export type Property_Authentication_DeletedAuthentication_Deleted_N_Allocation_A
   where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
 }
 
-export type Property_Authentication_DeletedAuthentication_Deleted_N_RewardArgs = {
+export type Property_Authentication_DeletedRewardArgs = {
   distinct_on?: Maybe<Array<Reward_Calculation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -4031,7 +4031,7 @@ export type Property_Authentication_DeletedAuthentication_Deleted_N_RewardArgs =
   where?: Maybe<Reward_Calculation_Result_Bool_Exp>
 }
 
-export type Property_Authentication_DeletedAuthentication_Deleted_N_Reward_AggregateArgs = {
+export type Property_Authentication_DeletedReward_AggregateArgs = {
   distinct_on?: Maybe<Array<Reward_Calculation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -4097,15 +4097,15 @@ export type Property_Authentication_Deleted_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Property_Authentication_Deleted_Bool_Exp>>>
   _not?: Maybe<Property_Authentication_Deleted_Bool_Exp>
   _or?: Maybe<Array<Maybe<Property_Authentication_Deleted_Bool_Exp>>>
-  authentication_deleted_n_allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
-  authentication_deleted_n_market?: Maybe<Market_Factory_Create_Bool_Exp>
-  authentication_deleted_n_property?: Maybe<Property_Factory_Create_Bool_Exp>
-  authentication_deleted_n_reward?: Maybe<Reward_Calculation_Result_Bool_Exp>
+  allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
   authentication_id?: Maybe<String_Comparison_Exp>
   block_number?: Maybe<Int_Comparison_Exp>
   market?: Maybe<String_Comparison_Exp>
+  market_creation?: Maybe<Market_Factory_Create_Bool_Exp>
   metrics?: Maybe<String_Comparison_Exp>
   property?: Maybe<String_Comparison_Exp>
+  property_creation?: Maybe<Property_Factory_Create_Bool_Exp>
+  reward?: Maybe<Reward_Calculation_Result_Bool_Exp>
 }
 
 export enum Property_Authentication_Deleted_Constraint {
@@ -4117,15 +4117,15 @@ export type Property_Authentication_Deleted_Inc_Input = {
 }
 
 export type Property_Authentication_Deleted_Insert_Input = {
-  authentication_deleted_n_allocation?: Maybe<Allocator_Allocation_Result_Arr_Rel_Insert_Input>
-  authentication_deleted_n_market?: Maybe<Market_Factory_Create_Obj_Rel_Insert_Input>
-  authentication_deleted_n_property?: Maybe<Property_Factory_Create_Obj_Rel_Insert_Input>
-  authentication_deleted_n_reward?: Maybe<Reward_Calculation_Result_Arr_Rel_Insert_Input>
+  allocation?: Maybe<Allocator_Allocation_Result_Arr_Rel_Insert_Input>
   authentication_id?: Maybe<Scalars['String']>
   block_number?: Maybe<Scalars['Int']>
   market?: Maybe<Scalars['String']>
+  market_creation?: Maybe<Market_Factory_Create_Obj_Rel_Insert_Input>
   metrics?: Maybe<Scalars['String']>
   property?: Maybe<Scalars['String']>
+  property_creation?: Maybe<Property_Factory_Create_Obj_Rel_Insert_Input>
+  reward?: Maybe<Reward_Calculation_Result_Arr_Rel_Insert_Input>
 }
 
 export type Property_Authentication_Deleted_Max_Fields = {
@@ -4180,15 +4180,15 @@ export type Property_Authentication_Deleted_On_Conflict = {
 }
 
 export type Property_Authentication_Deleted_Order_By = {
-  authentication_deleted_n_allocation_aggregate?: Maybe<Allocator_Allocation_Result_Aggregate_Order_By>
-  authentication_deleted_n_market?: Maybe<Market_Factory_Create_Order_By>
-  authentication_deleted_n_property?: Maybe<Property_Factory_Create_Order_By>
-  authentication_deleted_n_reward_aggregate?: Maybe<Reward_Calculation_Result_Aggregate_Order_By>
+  allocation_aggregate?: Maybe<Allocator_Allocation_Result_Aggregate_Order_By>
   authentication_id?: Maybe<Order_By>
   block_number?: Maybe<Order_By>
   market?: Maybe<Order_By>
+  market_creation?: Maybe<Market_Factory_Create_Order_By>
   metrics?: Maybe<Order_By>
   property?: Maybe<Order_By>
+  property_creation?: Maybe<Property_Factory_Create_Order_By>
+  reward_aggregate?: Maybe<Reward_Calculation_Result_Aggregate_Order_By>
 }
 
 export type Property_Authentication_Deleted_Pk_Columns_Input = {
@@ -4288,15 +4288,15 @@ export type Property_Authentication_Inc_Input = {
 }
 
 export type Property_Authentication_Insert_Input = {
+  allocation?: Maybe<Allocator_Allocation_Result_Arr_Rel_Insert_Input>
   authentication_id?: Maybe<Scalars['String']>
-  authentication_n_allocation?: Maybe<Allocator_Allocation_Result_Arr_Rel_Insert_Input>
-  authentication_n_market?: Maybe<Market_Factory_Create_Obj_Rel_Insert_Input>
-  authentication_n_property?: Maybe<Property_Factory_Create_Obj_Rel_Insert_Input>
-  authentication_n_reward?: Maybe<Reward_Calculation_Result_Arr_Rel_Insert_Input>
   block_number?: Maybe<Scalars['Int']>
   market?: Maybe<Scalars['String']>
+  market_creation?: Maybe<Market_Factory_Create_Obj_Rel_Insert_Input>
   metrics?: Maybe<Scalars['String']>
   property?: Maybe<Scalars['String']>
+  property_creation?: Maybe<Property_Factory_Create_Obj_Rel_Insert_Input>
+  reward?: Maybe<Reward_Calculation_Result_Arr_Rel_Insert_Input>
 }
 
 export type Property_Authentication_Max_Fields = {
@@ -4351,15 +4351,15 @@ export type Property_Authentication_On_Conflict = {
 }
 
 export type Property_Authentication_Order_By = {
+  allocation_aggregate?: Maybe<Allocator_Allocation_Result_Aggregate_Order_By>
   authentication_id?: Maybe<Order_By>
-  authentication_n_allocation_aggregate?: Maybe<Allocator_Allocation_Result_Aggregate_Order_By>
-  authentication_n_market?: Maybe<Market_Factory_Create_Order_By>
-  authentication_n_property?: Maybe<Property_Factory_Create_Order_By>
-  authentication_n_reward_aggregate?: Maybe<Reward_Calculation_Result_Aggregate_Order_By>
   block_number?: Maybe<Order_By>
   market?: Maybe<Order_By>
+  market_creation?: Maybe<Market_Factory_Create_Order_By>
   metrics?: Maybe<Order_By>
   property?: Maybe<Order_By>
+  property_creation?: Maybe<Property_Factory_Create_Order_By>
+  reward_aggregate?: Maybe<Reward_Calculation_Result_Aggregate_Order_By>
 }
 
 export type Property_Authentication_Pk_Columns_Input = {
@@ -4456,24 +4456,24 @@ export type Property_Authentication_Variance_Order_By = {
 
 export type Property_Factory_Create = {
   __typename?: 'property_factory_create'
+  allocation: Array<Allocator_Allocation_Result>
+  allocation_aggregate: Allocator_Allocation_Result_Aggregate
+  authentication: Array<Property_Authentication>
+  authentication_aggregate: Property_Authentication_Aggregate
   block_number: Scalars['Int']
+  deleted_authentication: Array<Property_Authentication_Deleted>
+  deleted_authentication_aggregate: Property_Authentication_Deleted_Aggregate
   event_id: Scalars['String']
   from_address: Scalars['String']
   log_index: Scalars['Int']
   property: Scalars['String']
-  property_n_allocation: Array<Allocator_Allocation_Result>
-  property_n_allocation_aggregate: Allocator_Allocation_Result_Aggregate
-  property_n_authentication: Array<Property_Authentication>
-  property_n_authentication_aggregate: Property_Authentication_Aggregate
-  property_n_authentication_deleted: Array<Property_Authentication_Deleted>
-  property_n_authentication_deleted_aggregate: Property_Authentication_Deleted_Aggregate
-  property_n_lockup: Array<Lockup_Lockedup>
-  property_n_lockup_aggregate: Lockup_Lockedup_Aggregate
+  property_creation: Array<Lockup_Lockedup>
+  property_creation_aggregate: Lockup_Lockedup_Aggregate
   raw_data: Scalars['String']
   transaction_index: Scalars['Int']
 }
 
-export type Property_Factory_CreateProperty_N_AllocationArgs = {
+export type Property_Factory_CreateAllocationArgs = {
   distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -4481,7 +4481,7 @@ export type Property_Factory_CreateProperty_N_AllocationArgs = {
   where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
 }
 
-export type Property_Factory_CreateProperty_N_Allocation_AggregateArgs = {
+export type Property_Factory_CreateAllocation_AggregateArgs = {
   distinct_on?: Maybe<Array<Allocator_Allocation_Result_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -4489,7 +4489,7 @@ export type Property_Factory_CreateProperty_N_Allocation_AggregateArgs = {
   where?: Maybe<Allocator_Allocation_Result_Bool_Exp>
 }
 
-export type Property_Factory_CreateProperty_N_AuthenticationArgs = {
+export type Property_Factory_CreateAuthenticationArgs = {
   distinct_on?: Maybe<Array<Property_Authentication_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -4497,7 +4497,7 @@ export type Property_Factory_CreateProperty_N_AuthenticationArgs = {
   where?: Maybe<Property_Authentication_Bool_Exp>
 }
 
-export type Property_Factory_CreateProperty_N_Authentication_AggregateArgs = {
+export type Property_Factory_CreateAuthentication_AggregateArgs = {
   distinct_on?: Maybe<Array<Property_Authentication_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -4505,7 +4505,7 @@ export type Property_Factory_CreateProperty_N_Authentication_AggregateArgs = {
   where?: Maybe<Property_Authentication_Bool_Exp>
 }
 
-export type Property_Factory_CreateProperty_N_Authentication_DeletedArgs = {
+export type Property_Factory_CreateDeleted_AuthenticationArgs = {
   distinct_on?: Maybe<Array<Property_Authentication_Deleted_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -4513,7 +4513,7 @@ export type Property_Factory_CreateProperty_N_Authentication_DeletedArgs = {
   where?: Maybe<Property_Authentication_Deleted_Bool_Exp>
 }
 
-export type Property_Factory_CreateProperty_N_Authentication_Deleted_AggregateArgs = {
+export type Property_Factory_CreateDeleted_Authentication_AggregateArgs = {
   distinct_on?: Maybe<Array<Property_Authentication_Deleted_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -4521,7 +4521,7 @@ export type Property_Factory_CreateProperty_N_Authentication_Deleted_AggregateAr
   where?: Maybe<Property_Authentication_Deleted_Bool_Exp>
 }
 
-export type Property_Factory_CreateProperty_N_LockupArgs = {
+export type Property_Factory_CreateProperty_CreationArgs = {
   distinct_on?: Maybe<Array<Lockup_Lockedup_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -4529,7 +4529,7 @@ export type Property_Factory_CreateProperty_N_LockupArgs = {
   where?: Maybe<Lockup_Lockedup_Bool_Exp>
 }
 
-export type Property_Factory_CreateProperty_N_Lockup_AggregateArgs = {
+export type Property_Factory_CreateProperty_Creation_AggregateArgs = {
   distinct_on?: Maybe<Array<Lockup_Lockedup_Select_Column>>
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
@@ -4599,15 +4599,15 @@ export type Property_Factory_Create_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Property_Factory_Create_Bool_Exp>>>
   _not?: Maybe<Property_Factory_Create_Bool_Exp>
   _or?: Maybe<Array<Maybe<Property_Factory_Create_Bool_Exp>>>
+  allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
+  authentication?: Maybe<Property_Authentication_Bool_Exp>
   block_number?: Maybe<Int_Comparison_Exp>
+  deleted_authentication?: Maybe<Property_Authentication_Deleted_Bool_Exp>
   event_id?: Maybe<String_Comparison_Exp>
   from_address?: Maybe<String_Comparison_Exp>
   log_index?: Maybe<Int_Comparison_Exp>
   property?: Maybe<String_Comparison_Exp>
-  property_n_allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
-  property_n_authentication?: Maybe<Property_Authentication_Bool_Exp>
-  property_n_authentication_deleted?: Maybe<Property_Authentication_Deleted_Bool_Exp>
-  property_n_lockup?: Maybe<Lockup_Lockedup_Bool_Exp>
+  property_creation?: Maybe<Lockup_Lockedup_Bool_Exp>
   raw_data?: Maybe<String_Comparison_Exp>
   transaction_index?: Maybe<Int_Comparison_Exp>
 }
@@ -4623,15 +4623,15 @@ export type Property_Factory_Create_Inc_Input = {
 }
 
 export type Property_Factory_Create_Insert_Input = {
+  allocation?: Maybe<Allocator_Allocation_Result_Arr_Rel_Insert_Input>
+  authentication?: Maybe<Property_Authentication_Arr_Rel_Insert_Input>
   block_number?: Maybe<Scalars['Int']>
+  deleted_authentication?: Maybe<Property_Authentication_Deleted_Arr_Rel_Insert_Input>
   event_id?: Maybe<Scalars['String']>
   from_address?: Maybe<Scalars['String']>
   log_index?: Maybe<Scalars['Int']>
   property?: Maybe<Scalars['String']>
-  property_n_allocation?: Maybe<Allocator_Allocation_Result_Arr_Rel_Insert_Input>
-  property_n_authentication?: Maybe<Property_Authentication_Arr_Rel_Insert_Input>
-  property_n_authentication_deleted?: Maybe<Property_Authentication_Deleted_Arr_Rel_Insert_Input>
-  property_n_lockup?: Maybe<Lockup_Lockedup_Arr_Rel_Insert_Input>
+  property_creation?: Maybe<Lockup_Lockedup_Arr_Rel_Insert_Input>
   raw_data?: Maybe<Scalars['String']>
   transaction_index?: Maybe<Scalars['Int']>
 }
@@ -4696,15 +4696,15 @@ export type Property_Factory_Create_On_Conflict = {
 }
 
 export type Property_Factory_Create_Order_By = {
+  allocation_aggregate?: Maybe<Allocator_Allocation_Result_Aggregate_Order_By>
+  authentication_aggregate?: Maybe<Property_Authentication_Aggregate_Order_By>
   block_number?: Maybe<Order_By>
+  deleted_authentication_aggregate?: Maybe<Property_Authentication_Deleted_Aggregate_Order_By>
   event_id?: Maybe<Order_By>
   from_address?: Maybe<Order_By>
   log_index?: Maybe<Order_By>
   property?: Maybe<Order_By>
-  property_n_allocation_aggregate?: Maybe<Allocator_Allocation_Result_Aggregate_Order_By>
-  property_n_authentication_aggregate?: Maybe<Property_Authentication_Aggregate_Order_By>
-  property_n_authentication_deleted_aggregate?: Maybe<Property_Authentication_Deleted_Aggregate_Order_By>
-  property_n_lockup_aggregate?: Maybe<Lockup_Lockedup_Aggregate_Order_By>
+  property_creation_aggregate?: Maybe<Lockup_Lockedup_Aggregate_Order_By>
   raw_data?: Maybe<Order_By>
   transaction_index?: Maybe<Order_By>
 }
@@ -5132,16 +5132,16 @@ export type Query_RootReward_Calculation_Result_By_PkArgs = {
 export type Reward_Calculation_Result = {
   __typename?: 'reward_calculation_result'
   allocate_result: Scalars['numeric']
+  allocation?: Maybe<Allocator_Allocation_Result>
   alocator_allocation_result_event_id: Scalars['String']
+  authentication?: Maybe<Property_Authentication>
   block_number: Scalars['Int']
   holder_reward: Scalars['numeric']
   lockup: Scalars['numeric']
   metrics: Scalars['String']
+  metrics_creation?: Maybe<Metrics_Factory_Create>
   policy: Scalars['String']
-  reward_n_allocation?: Maybe<Allocator_Allocation_Result>
-  reward_n_authentication?: Maybe<Property_Authentication>
-  reward_n_metrics?: Maybe<Metrics_Factory_Create>
-  reward_n_policy?: Maybe<Policy_Factory_Create>
+  policy_creation?: Maybe<Policy_Factory_Create>
   staking_reward: Scalars['numeric']
 }
 
@@ -5212,16 +5212,16 @@ export type Reward_Calculation_Result_Bool_Exp = {
   _not?: Maybe<Reward_Calculation_Result_Bool_Exp>
   _or?: Maybe<Array<Maybe<Reward_Calculation_Result_Bool_Exp>>>
   allocate_result?: Maybe<Numeric_Comparison_Exp>
+  allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
   alocator_allocation_result_event_id?: Maybe<String_Comparison_Exp>
+  authentication?: Maybe<Property_Authentication_Bool_Exp>
   block_number?: Maybe<Int_Comparison_Exp>
   holder_reward?: Maybe<Numeric_Comparison_Exp>
   lockup?: Maybe<Numeric_Comparison_Exp>
   metrics?: Maybe<String_Comparison_Exp>
+  metrics_creation?: Maybe<Metrics_Factory_Create_Bool_Exp>
   policy?: Maybe<String_Comparison_Exp>
-  reward_n_allocation?: Maybe<Allocator_Allocation_Result_Bool_Exp>
-  reward_n_authentication?: Maybe<Property_Authentication_Bool_Exp>
-  reward_n_metrics?: Maybe<Metrics_Factory_Create_Bool_Exp>
-  reward_n_policy?: Maybe<Policy_Factory_Create_Bool_Exp>
+  policy_creation?: Maybe<Policy_Factory_Create_Bool_Exp>
   staking_reward?: Maybe<Numeric_Comparison_Exp>
 }
 
@@ -5239,16 +5239,16 @@ export type Reward_Calculation_Result_Inc_Input = {
 
 export type Reward_Calculation_Result_Insert_Input = {
   allocate_result?: Maybe<Scalars['numeric']>
+  allocation?: Maybe<Allocator_Allocation_Result_Obj_Rel_Insert_Input>
   alocator_allocation_result_event_id?: Maybe<Scalars['String']>
+  authentication?: Maybe<Property_Authentication_Obj_Rel_Insert_Input>
   block_number?: Maybe<Scalars['Int']>
   holder_reward?: Maybe<Scalars['numeric']>
   lockup?: Maybe<Scalars['numeric']>
   metrics?: Maybe<Scalars['String']>
+  metrics_creation?: Maybe<Metrics_Factory_Create_Obj_Rel_Insert_Input>
   policy?: Maybe<Scalars['String']>
-  reward_n_allocation?: Maybe<Allocator_Allocation_Result_Obj_Rel_Insert_Input>
-  reward_n_authentication?: Maybe<Property_Authentication_Obj_Rel_Insert_Input>
-  reward_n_metrics?: Maybe<Metrics_Factory_Create_Obj_Rel_Insert_Input>
-  reward_n_policy?: Maybe<Policy_Factory_Create_Obj_Rel_Insert_Input>
+  policy_creation?: Maybe<Policy_Factory_Create_Obj_Rel_Insert_Input>
   staking_reward?: Maybe<Scalars['numeric']>
 }
 
@@ -5317,16 +5317,16 @@ export type Reward_Calculation_Result_On_Conflict = {
 
 export type Reward_Calculation_Result_Order_By = {
   allocate_result?: Maybe<Order_By>
+  allocation?: Maybe<Allocator_Allocation_Result_Order_By>
   alocator_allocation_result_event_id?: Maybe<Order_By>
+  authentication?: Maybe<Property_Authentication_Order_By>
   block_number?: Maybe<Order_By>
   holder_reward?: Maybe<Order_By>
   lockup?: Maybe<Order_By>
   metrics?: Maybe<Order_By>
+  metrics_creation?: Maybe<Metrics_Factory_Create_Order_By>
   policy?: Maybe<Order_By>
-  reward_n_allocation?: Maybe<Allocator_Allocation_Result_Order_By>
-  reward_n_authentication?: Maybe<Property_Authentication_Order_By>
-  reward_n_metrics?: Maybe<Metrics_Factory_Create_Order_By>
-  reward_n_policy?: Maybe<Policy_Factory_Create_Order_By>
+  policy_creation?: Maybe<Policy_Factory_Create_Order_By>
   staking_reward?: Maybe<Order_By>
 }
 
@@ -6197,7 +6197,7 @@ export const ListPropertyDocument = gql`
     property_factory_create(
       limit: $limit
       offset: $offset
-      order_by: { property_n_allocation_aggregate: { sum: { result: desc_nulls_last } } }
+      order_by: { allocation_aggregate: { sum: { result: desc_nulls_last } } }
     ) {
       ...propertyFactoryCreate
     }

--- a/packages/graphql/src/react-apollo/generated.tsx
+++ b/packages/graphql/src/react-apollo/generated.tsx
@@ -6194,7 +6194,11 @@ export type ListAllocatorAllocationResultsQueryResult = ApolloReactCommon.QueryR
 >
 export const ListPropertyDocument = gql`
   query ListProperty($limit: Int, $offset: Int) {
-    property_factory_create(limit: $limit, offset: $offset) {
+    property_factory_create(
+      limit: $limit
+      offset: $offset
+      order_by: { property_n_allocation_aggregate: { sum: { result: desc_nulls_last } } }
+    ) {
       ...propertyFactoryCreate
     }
     property_factory_create_aggregate {

--- a/packages/graphql/src/scheme.graphql
+++ b/packages/graphql/src/scheme.graphql
@@ -6,15 +6,10 @@ schema {
 
 # columns and relationships of "allocator_allocation_result"
 type allocator_allocation_result {
-  # An object relationship
-  allocation_n_authentication: property_authentication
-
-  # An object relationship
-  allocation_n_property: property_factory_create
-
-  # An object relationship
-  allocation_n_reward: reward_calculation_result
   arg_value: numeric!
+
+  # An object relationship
+  authentication: property_authentication
   block_number: Int!
   event_id: String!
   lockup_value: numeric!
@@ -22,8 +17,14 @@ type allocator_allocation_result {
   market: String!
   metrics: String!
   property: String!
+
+  # An object relationship
+  property_creation: property_factory_create
   raw_data: String!
   result: numeric!
+
+  # An object relationship
+  reward: reward_calculation_result
   transaction_index: Int!
 }
 
@@ -95,10 +96,8 @@ input allocator_allocation_result_bool_exp {
   _and: [allocator_allocation_result_bool_exp]
   _not: allocator_allocation_result_bool_exp
   _or: [allocator_allocation_result_bool_exp]
-  allocation_n_authentication: property_authentication_bool_exp
-  allocation_n_property: property_factory_create_bool_exp
-  allocation_n_reward: reward_calculation_result_bool_exp
   arg_value: numeric_comparison_exp
+  authentication: property_authentication_bool_exp
   block_number: Int_comparison_exp
   event_id: String_comparison_exp
   lockup_value: numeric_comparison_exp
@@ -106,8 +105,10 @@ input allocator_allocation_result_bool_exp {
   market: String_comparison_exp
   metrics: String_comparison_exp
   property: String_comparison_exp
+  property_creation: property_factory_create_bool_exp
   raw_data: String_comparison_exp
   result: numeric_comparison_exp
+  reward: reward_calculation_result_bool_exp
   transaction_index: Int_comparison_exp
 }
 
@@ -129,10 +130,8 @@ input allocator_allocation_result_inc_input {
 
 # input type for inserting data into table "allocator_allocation_result"
 input allocator_allocation_result_insert_input {
-  allocation_n_authentication: property_authentication_obj_rel_insert_input
-  allocation_n_property: property_factory_create_obj_rel_insert_input
-  allocation_n_reward: reward_calculation_result_obj_rel_insert_input
   arg_value: numeric
+  authentication: property_authentication_obj_rel_insert_input
   block_number: Int
   event_id: String
   lockup_value: numeric
@@ -140,8 +139,10 @@ input allocator_allocation_result_insert_input {
   market: String
   metrics: String
   property: String
+  property_creation: property_factory_create_obj_rel_insert_input
   raw_data: String
   result: numeric
+  reward: reward_calculation_result_obj_rel_insert_input
   transaction_index: Int
 }
 
@@ -229,10 +230,8 @@ input allocator_allocation_result_on_conflict {
 
 # ordering options when selecting data from "allocator_allocation_result"
 input allocator_allocation_result_order_by {
-  allocation_n_authentication: property_authentication_order_by
-  allocation_n_property: property_factory_create_order_by
-  allocation_n_reward: reward_calculation_result_order_by
   arg_value: order_by
+  authentication: property_authentication_order_by
   block_number: order_by
   event_id: order_by
   lockup_value: order_by
@@ -240,8 +239,10 @@ input allocator_allocation_result_order_by {
   market: order_by
   metrics: order_by
   property: order_by
+  property_creation: property_factory_create_order_by
   raw_data: order_by
   result: order_by
+  reward: reward_calculation_result_order_by
   transaction_index: order_by
 }
 
@@ -1042,12 +1043,8 @@ input Int_comparison_exp {
 
 # columns and relationships of "lockup_lockedup"
 type lockup_lockedup {
-  block_number: Int!
-  event_id: String!
-  from_address: String!
-
   # An array relationship
-  lockup_n_allocation(
+  allocation(
     # distinct select on columns
     distinct_on: [allocator_allocation_result_select_column!]
 
@@ -1065,7 +1062,7 @@ type lockup_lockedup {
   ): [allocator_allocation_result!]!
 
   # An aggregated array relationship
-  lockup_n_allocation_aggregate(
+  allocation_aggregate(
     # distinct select on columns
     distinct_on: [allocator_allocation_result_select_column!]
 
@@ -1081,11 +1078,14 @@ type lockup_lockedup {
     # filter the rows returned
     where: allocator_allocation_result_bool_exp
   ): allocator_allocation_result_aggregate!
-
-  # An object relationship
-  lockup_n_property: property_factory_create
+  block_number: Int!
+  event_id: String!
+  from_address: String!
   log_index: Int!
   property: String!
+
+  # An object relationship
+  property_creation: property_factory_create
   raw_data: String!
   token_value: numeric!
   transaction_index: Int!
@@ -1154,13 +1154,13 @@ input lockup_lockedup_bool_exp {
   _and: [lockup_lockedup_bool_exp]
   _not: lockup_lockedup_bool_exp
   _or: [lockup_lockedup_bool_exp]
+  allocation: allocator_allocation_result_bool_exp
   block_number: Int_comparison_exp
   event_id: String_comparison_exp
   from_address: String_comparison_exp
-  lockup_n_allocation: allocator_allocation_result_bool_exp
-  lockup_n_property: property_factory_create_bool_exp
   log_index: Int_comparison_exp
   property: String_comparison_exp
+  property_creation: property_factory_create_bool_exp
   raw_data: String_comparison_exp
   token_value: numeric_comparison_exp
   transaction_index: Int_comparison_exp
@@ -1182,13 +1182,13 @@ input lockup_lockedup_inc_input {
 
 # input type for inserting data into table "lockup_lockedup"
 input lockup_lockedup_insert_input {
+  allocation: allocator_allocation_result_arr_rel_insert_input
   block_number: Int
   event_id: String
   from_address: String
-  lockup_n_allocation: allocator_allocation_result_arr_rel_insert_input
-  lockup_n_property: property_factory_create_obj_rel_insert_input
   log_index: Int
   property: String
+  property_creation: property_factory_create_obj_rel_insert_input
   raw_data: String
   token_value: numeric
   transaction_index: Int
@@ -1266,13 +1266,13 @@ input lockup_lockedup_on_conflict {
 
 # ordering options when selecting data from "lockup_lockedup"
 input lockup_lockedup_order_by {
+  allocation_aggregate: allocator_allocation_result_aggregate_order_by
   block_number: order_by
   event_id: order_by
   from_address: order_by
-  lockup_n_allocation_aggregate: allocator_allocation_result_aggregate_order_by
-  lockup_n_property: property_factory_create_order_by
   log_index: order_by
   property: order_by
+  property_creation: property_factory_create_order_by
   raw_data: order_by
   token_value: order_by
   transaction_index: order_by
@@ -1463,14 +1463,8 @@ input lockup_lockedup_variance_order_by {
 
 # columns and relationships of "market_factory_create"
 type market_factory_create {
-  block_number: Int!
-  event_id: String!
-  from_address: String!
-  log_index: Int!
-  market: String!
-
   # An array relationship
-  market_n_allocation(
+  allocation(
     # distinct select on columns
     distinct_on: [allocator_allocation_result_select_column!]
 
@@ -1488,7 +1482,7 @@ type market_factory_create {
   ): [allocator_allocation_result!]!
 
   # An aggregated array relationship
-  market_n_allocation_aggregate(
+  allocation_aggregate(
     # distinct select on columns
     distinct_on: [allocator_allocation_result_select_column!]
 
@@ -1504,45 +1498,10 @@ type market_factory_create {
     # filter the rows returned
     where: allocator_allocation_result_bool_exp
   ): allocator_allocation_result_aggregate!
+  block_number: Int!
 
   # An array relationship
-  market_n_metrics(
-    # distinct select on columns
-    distinct_on: [metrics_factory_create_select_column!]
-
-    # limit the number of rows returned
-    limit: Int
-
-    # skip the first n rows. Use only with order_by
-    offset: Int
-
-    # sort the rows by one or more columns
-    order_by: [metrics_factory_create_order_by!]
-
-    # filter the rows returned
-    where: metrics_factory_create_bool_exp
-  ): [metrics_factory_create!]!
-
-  # An aggregated array relationship
-  market_n_metrics_aggregate(
-    # distinct select on columns
-    distinct_on: [metrics_factory_create_select_column!]
-
-    # limit the number of rows returned
-    limit: Int
-
-    # skip the first n rows. Use only with order_by
-    offset: Int
-
-    # sort the rows by one or more columns
-    order_by: [metrics_factory_create_order_by!]
-
-    # filter the rows returned
-    where: metrics_factory_create_bool_exp
-  ): metrics_factory_create_aggregate!
-
-  # An array relationship
-  market_n_metrics_destroy(
+  destroyed_metrics(
     # distinct select on columns
     distinct_on: [metrics_factory_destroy_select_column!]
 
@@ -1560,7 +1519,7 @@ type market_factory_create {
   ): [metrics_factory_destroy!]!
 
   # An aggregated array relationship
-  market_n_metrics_destroy_aggregate(
+  destroyed_metrics_aggregate(
     # distinct select on columns
     distinct_on: [metrics_factory_destroy_select_column!]
 
@@ -1576,6 +1535,46 @@ type market_factory_create {
     # filter the rows returned
     where: metrics_factory_destroy_bool_exp
   ): metrics_factory_destroy_aggregate!
+  event_id: String!
+  from_address: String!
+  log_index: Int!
+  market: String!
+
+  # An array relationship
+  metrics(
+    # distinct select on columns
+    distinct_on: [metrics_factory_create_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [metrics_factory_create_order_by!]
+
+    # filter the rows returned
+    where: metrics_factory_create_bool_exp
+  ): [metrics_factory_create!]!
+
+  # An aggregated array relationship
+  metrics_aggregate(
+    # distinct select on columns
+    distinct_on: [metrics_factory_create_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [metrics_factory_create_order_by!]
+
+    # filter the rows returned
+    where: metrics_factory_create_bool_exp
+  ): metrics_factory_create_aggregate!
   raw_data: String!
   transaction_index: Int!
 }
@@ -1641,14 +1640,14 @@ input market_factory_create_bool_exp {
   _and: [market_factory_create_bool_exp]
   _not: market_factory_create_bool_exp
   _or: [market_factory_create_bool_exp]
+  allocation: allocator_allocation_result_bool_exp
   block_number: Int_comparison_exp
+  destroyed_metrics: metrics_factory_destroy_bool_exp
   event_id: String_comparison_exp
   from_address: String_comparison_exp
   log_index: Int_comparison_exp
   market: String_comparison_exp
-  market_n_allocation: allocator_allocation_result_bool_exp
-  market_n_metrics: metrics_factory_create_bool_exp
-  market_n_metrics_destroy: metrics_factory_destroy_bool_exp
+  metrics: metrics_factory_create_bool_exp
   raw_data: String_comparison_exp
   transaction_index: Int_comparison_exp
 }
@@ -1668,14 +1667,14 @@ input market_factory_create_inc_input {
 
 # input type for inserting data into table "market_factory_create"
 input market_factory_create_insert_input {
+  allocation: allocator_allocation_result_arr_rel_insert_input
   block_number: Int
+  destroyed_metrics: metrics_factory_destroy_arr_rel_insert_input
   event_id: String
   from_address: String
   log_index: Int
   market: String
-  market_n_allocation: allocator_allocation_result_arr_rel_insert_input
-  market_n_metrics: metrics_factory_create_arr_rel_insert_input
-  market_n_metrics_destroy: metrics_factory_destroy_arr_rel_insert_input
+  metrics: metrics_factory_create_arr_rel_insert_input
   raw_data: String
   transaction_index: Int
 }
@@ -1748,14 +1747,14 @@ input market_factory_create_on_conflict {
 
 # ordering options when selecting data from "market_factory_create"
 input market_factory_create_order_by {
+  allocation_aggregate: allocator_allocation_result_aggregate_order_by
   block_number: order_by
+  destroyed_metrics_aggregate: metrics_factory_destroy_aggregate_order_by
   event_id: order_by
   from_address: order_by
   log_index: order_by
   market: order_by
-  market_n_allocation_aggregate: allocator_allocation_result_aggregate_order_by
-  market_n_metrics_aggregate: metrics_factory_create_aggregate_order_by
-  market_n_metrics_destroy_aggregate: metrics_factory_destroy_aggregate_order_by
+  metrics_aggregate: metrics_factory_create_aggregate_order_by
   raw_data: order_by
   transaction_index: order_by
 }
@@ -1925,16 +1924,16 @@ input market_factory_create_variance_order_by {
 # columns and relationships of "metrics_factory_create"
 type metrics_factory_create {
   block_number: Int!
+
+  # An object relationship
+  destroyed_metrics: metrics_factory_destroy
   event_id: String!
   from_address: String!
   log_index: Int!
+
+  # An object relationship
+  market: market_factory_create
   metrics: String!
-
-  # An object relationship
-  metrics_n_market: market_factory_create
-
-  # An object relationship
-  metrics_n_metrics_destroy: metrics_factory_destroy
   raw_data: String!
   transaction_index: Int!
 }
@@ -2001,12 +2000,12 @@ input metrics_factory_create_bool_exp {
   _not: metrics_factory_create_bool_exp
   _or: [metrics_factory_create_bool_exp]
   block_number: Int_comparison_exp
+  destroyed_metrics: metrics_factory_destroy_bool_exp
   event_id: String_comparison_exp
   from_address: String_comparison_exp
   log_index: Int_comparison_exp
+  market: market_factory_create_bool_exp
   metrics: String_comparison_exp
-  metrics_n_market: market_factory_create_bool_exp
-  metrics_n_metrics_destroy: metrics_factory_destroy_bool_exp
   raw_data: String_comparison_exp
   transaction_index: Int_comparison_exp
 }
@@ -2027,12 +2026,12 @@ input metrics_factory_create_inc_input {
 # input type for inserting data into table "metrics_factory_create"
 input metrics_factory_create_insert_input {
   block_number: Int
+  destroyed_metrics: metrics_factory_destroy_obj_rel_insert_input
   event_id: String
   from_address: String
   log_index: Int
+  market: market_factory_create_obj_rel_insert_input
   metrics: String
-  metrics_n_market: market_factory_create_obj_rel_insert_input
-  metrics_n_metrics_destroy: metrics_factory_destroy_obj_rel_insert_input
   raw_data: String
   transaction_index: Int
 }
@@ -2106,12 +2105,12 @@ input metrics_factory_create_on_conflict {
 # ordering options when selecting data from "metrics_factory_create"
 input metrics_factory_create_order_by {
   block_number: order_by
+  destroyed_metrics: metrics_factory_destroy_order_by
   event_id: order_by
   from_address: order_by
   log_index: order_by
+  market: market_factory_create_order_by
   metrics: order_by
-  metrics_n_market: market_factory_create_order_by
-  metrics_n_metrics_destroy: metrics_factory_destroy_order_by
   raw_data: order_by
   transaction_index: order_by
 }
@@ -2284,13 +2283,13 @@ type metrics_factory_destroy {
   event_id: String!
   from_address: String!
   log_index: Int!
+
+  # An object relationship
+  market: market_factory_create
   metrics: String!
 
   # An object relationship
-  metrics_destroy_n_market: market_factory_create
-
-  # An object relationship
-  metrics_destroy_n_metrics: metrics_factory_create
+  metrics_creation: metrics_factory_create
   raw_data: String!
   transaction_index: Int!
 }
@@ -2360,9 +2359,9 @@ input metrics_factory_destroy_bool_exp {
   event_id: String_comparison_exp
   from_address: String_comparison_exp
   log_index: Int_comparison_exp
+  market: market_factory_create_bool_exp
   metrics: String_comparison_exp
-  metrics_destroy_n_market: market_factory_create_bool_exp
-  metrics_destroy_n_metrics: metrics_factory_create_bool_exp
+  metrics_creation: metrics_factory_create_bool_exp
   raw_data: String_comparison_exp
   transaction_index: Int_comparison_exp
 }
@@ -2386,9 +2385,9 @@ input metrics_factory_destroy_insert_input {
   event_id: String
   from_address: String
   log_index: Int
+  market: market_factory_create_obj_rel_insert_input
   metrics: String
-  metrics_destroy_n_market: market_factory_create_obj_rel_insert_input
-  metrics_destroy_n_metrics: metrics_factory_create_obj_rel_insert_input
+  metrics_creation: metrics_factory_create_obj_rel_insert_input
   raw_data: String
   transaction_index: Int
 }
@@ -2465,9 +2464,9 @@ input metrics_factory_destroy_order_by {
   event_id: order_by
   from_address: order_by
   log_index: order_by
+  market: market_factory_create_order_by
   metrics: order_by
-  metrics_destroy_n_market: market_factory_create_order_by
-  metrics_destroy_n_metrics: metrics_factory_create_order_by
+  metrics_creation: metrics_factory_create_order_by
   raw_data: order_by
   transaction_index: order_by
 }
@@ -4199,9 +4198,10 @@ type policy_factory_create {
   inner_policy: String!
   log_index: Int!
   policy_address: String!
+  raw_data: String!
 
   # An array relationship
-  policy_n_reward(
+  reward(
     # distinct select on columns
     distinct_on: [reward_calculation_result_select_column!]
 
@@ -4219,7 +4219,7 @@ type policy_factory_create {
   ): [reward_calculation_result!]!
 
   # An aggregated array relationship
-  policy_n_reward_aggregate(
+  reward_aggregate(
     # distinct select on columns
     distinct_on: [reward_calculation_result_select_column!]
 
@@ -4235,7 +4235,6 @@ type policy_factory_create {
     # filter the rows returned
     where: reward_calculation_result_bool_exp
   ): reward_calculation_result_aggregate!
-  raw_data: String!
   transaction_index: Int!
 }
 
@@ -4306,8 +4305,8 @@ input policy_factory_create_bool_exp {
   inner_policy: String_comparison_exp
   log_index: Int_comparison_exp
   policy_address: String_comparison_exp
-  policy_n_reward: reward_calculation_result_bool_exp
   raw_data: String_comparison_exp
+  reward: reward_calculation_result_bool_exp
   transaction_index: Int_comparison_exp
 }
 
@@ -4332,8 +4331,8 @@ input policy_factory_create_insert_input {
   inner_policy: String
   log_index: Int
   policy_address: String
-  policy_n_reward: reward_calculation_result_arr_rel_insert_input
   raw_data: String
+  reward: reward_calculation_result_arr_rel_insert_input
   transaction_index: Int
 }
 
@@ -4415,8 +4414,8 @@ input policy_factory_create_order_by {
   inner_policy: order_by
   log_index: order_by
   policy_address: order_by
-  policy_n_reward_aggregate: reward_calculation_result_aggregate_order_by
   raw_data: order_by
+  reward_aggregate: reward_calculation_result_aggregate_order_by
   transaction_index: order_by
 }
 
@@ -4591,10 +4590,8 @@ input policy_factory_create_variance_order_by {
 
 # columns and relationships of "property_authentication"
 type property_authentication {
-  authentication_id: String!
-
   # An array relationship
-  authentication_n_allocation(
+  allocation(
     # distinct select on columns
     distinct_on: [allocator_allocation_result_select_column!]
 
@@ -4612,7 +4609,7 @@ type property_authentication {
   ): [allocator_allocation_result!]!
 
   # An aggregated array relationship
-  authentication_n_allocation_aggregate(
+  allocation_aggregate(
     # distinct select on columns
     distinct_on: [allocator_allocation_result_select_column!]
 
@@ -4628,15 +4625,20 @@ type property_authentication {
     # filter the rows returned
     where: allocator_allocation_result_bool_exp
   ): allocator_allocation_result_aggregate!
+  authentication_id: String!
+  block_number: Int!
+  market: String!
 
   # An object relationship
-  authentication_n_market: market_factory_create
+  market_creation: market_factory_create
+  metrics: String!
+  property: String!
 
   # An object relationship
-  authentication_n_property: property_factory_create
+  property_creation: property_factory_create
 
   # An array relationship
-  authentication_n_reward(
+  reward(
     # distinct select on columns
     distinct_on: [reward_calculation_result_select_column!]
 
@@ -4654,7 +4656,7 @@ type property_authentication {
   ): [reward_calculation_result!]!
 
   # An aggregated array relationship
-  authentication_n_reward_aggregate(
+  reward_aggregate(
     # distinct select on columns
     distinct_on: [reward_calculation_result_select_column!]
 
@@ -4670,10 +4672,6 @@ type property_authentication {
     # filter the rows returned
     where: reward_calculation_result_bool_exp
   ): reward_calculation_result_aggregate!
-  block_number: Int!
-  market: String!
-  metrics: String!
-  property: String!
 }
 
 # aggregated selection of "property_authentication"
@@ -4733,15 +4731,15 @@ input property_authentication_bool_exp {
   _and: [property_authentication_bool_exp]
   _not: property_authentication_bool_exp
   _or: [property_authentication_bool_exp]
+  allocation: allocator_allocation_result_bool_exp
   authentication_id: String_comparison_exp
-  authentication_n_allocation: allocator_allocation_result_bool_exp
-  authentication_n_market: market_factory_create_bool_exp
-  authentication_n_property: property_factory_create_bool_exp
-  authentication_n_reward: reward_calculation_result_bool_exp
   block_number: Int_comparison_exp
   market: String_comparison_exp
+  market_creation: market_factory_create_bool_exp
   metrics: String_comparison_exp
   property: String_comparison_exp
+  property_creation: property_factory_create_bool_exp
+  reward: reward_calculation_result_bool_exp
 }
 
 # unique or primary key constraints on table "property_authentication"
@@ -4753,7 +4751,7 @@ enum property_authentication_constraint {
 # columns and relationships of "property_authentication_deleted"
 type property_authentication_deleted {
   # An array relationship
-  authentication_deleted_n_allocation(
+  allocation(
     # distinct select on columns
     distinct_on: [allocator_allocation_result_select_column!]
 
@@ -4771,7 +4769,7 @@ type property_authentication_deleted {
   ): [allocator_allocation_result!]!
 
   # An aggregated array relationship
-  authentication_deleted_n_allocation_aggregate(
+  allocation_aggregate(
     # distinct select on columns
     distinct_on: [allocator_allocation_result_select_column!]
 
@@ -4787,15 +4785,20 @@ type property_authentication_deleted {
     # filter the rows returned
     where: allocator_allocation_result_bool_exp
   ): allocator_allocation_result_aggregate!
+  authentication_id: String!
+  block_number: Int!
+  market: String!
 
   # An object relationship
-  authentication_deleted_n_market: market_factory_create
+  market_creation: market_factory_create
+  metrics: String!
+  property: String!
 
   # An object relationship
-  authentication_deleted_n_property: property_factory_create
+  property_creation: property_factory_create
 
   # An array relationship
-  authentication_deleted_n_reward(
+  reward(
     # distinct select on columns
     distinct_on: [reward_calculation_result_select_column!]
 
@@ -4813,7 +4816,7 @@ type property_authentication_deleted {
   ): [reward_calculation_result!]!
 
   # An aggregated array relationship
-  authentication_deleted_n_reward_aggregate(
+  reward_aggregate(
     # distinct select on columns
     distinct_on: [reward_calculation_result_select_column!]
 
@@ -4829,11 +4832,6 @@ type property_authentication_deleted {
     # filter the rows returned
     where: reward_calculation_result_bool_exp
   ): reward_calculation_result_aggregate!
-  authentication_id: String!
-  block_number: Int!
-  market: String!
-  metrics: String!
-  property: String!
 }
 
 # aggregated selection of "property_authentication_deleted"
@@ -4894,15 +4892,15 @@ input property_authentication_deleted_bool_exp {
   _and: [property_authentication_deleted_bool_exp]
   _not: property_authentication_deleted_bool_exp
   _or: [property_authentication_deleted_bool_exp]
-  authentication_deleted_n_allocation: allocator_allocation_result_bool_exp
-  authentication_deleted_n_market: market_factory_create_bool_exp
-  authentication_deleted_n_property: property_factory_create_bool_exp
-  authentication_deleted_n_reward: reward_calculation_result_bool_exp
+  allocation: allocator_allocation_result_bool_exp
   authentication_id: String_comparison_exp
   block_number: Int_comparison_exp
   market: String_comparison_exp
+  market_creation: market_factory_create_bool_exp
   metrics: String_comparison_exp
   property: String_comparison_exp
+  property_creation: property_factory_create_bool_exp
+  reward: reward_calculation_result_bool_exp
 }
 
 # unique or primary key constraints on table "property_authentication_deleted"
@@ -4918,15 +4916,15 @@ input property_authentication_deleted_inc_input {
 
 # input type for inserting data into table "property_authentication_deleted"
 input property_authentication_deleted_insert_input {
-  authentication_deleted_n_allocation: allocator_allocation_result_arr_rel_insert_input
-  authentication_deleted_n_market: market_factory_create_obj_rel_insert_input
-  authentication_deleted_n_property: property_factory_create_obj_rel_insert_input
-  authentication_deleted_n_reward: reward_calculation_result_arr_rel_insert_input
+  allocation: allocator_allocation_result_arr_rel_insert_input
   authentication_id: String
   block_number: Int
   market: String
+  market_creation: market_factory_create_obj_rel_insert_input
   metrics: String
   property: String
+  property_creation: property_factory_create_obj_rel_insert_input
+  reward: reward_calculation_result_arr_rel_insert_input
 }
 
 # aggregate max on columns
@@ -4989,15 +4987,15 @@ input property_authentication_deleted_on_conflict {
 
 # ordering options when selecting data from "property_authentication_deleted"
 input property_authentication_deleted_order_by {
-  authentication_deleted_n_allocation_aggregate: allocator_allocation_result_aggregate_order_by
-  authentication_deleted_n_market: market_factory_create_order_by
-  authentication_deleted_n_property: property_factory_create_order_by
-  authentication_deleted_n_reward_aggregate: reward_calculation_result_aggregate_order_by
+  allocation_aggregate: allocator_allocation_result_aggregate_order_by
   authentication_id: order_by
   block_number: order_by
   market: order_by
+  market_creation: market_factory_create_order_by
   metrics: order_by
   property: order_by
+  property_creation: property_factory_create_order_by
+  reward_aggregate: reward_calculation_result_aggregate_order_by
 }
 
 # primary key columns input for table: "property_authentication_deleted"
@@ -5128,15 +5126,15 @@ input property_authentication_inc_input {
 
 # input type for inserting data into table "property_authentication"
 input property_authentication_insert_input {
+  allocation: allocator_allocation_result_arr_rel_insert_input
   authentication_id: String
-  authentication_n_allocation: allocator_allocation_result_arr_rel_insert_input
-  authentication_n_market: market_factory_create_obj_rel_insert_input
-  authentication_n_property: property_factory_create_obj_rel_insert_input
-  authentication_n_reward: reward_calculation_result_arr_rel_insert_input
   block_number: Int
   market: String
+  market_creation: market_factory_create_obj_rel_insert_input
   metrics: String
   property: String
+  property_creation: property_factory_create_obj_rel_insert_input
+  reward: reward_calculation_result_arr_rel_insert_input
 }
 
 # aggregate max on columns
@@ -5199,15 +5197,15 @@ input property_authentication_on_conflict {
 
 # ordering options when selecting data from "property_authentication"
 input property_authentication_order_by {
+  allocation_aggregate: allocator_allocation_result_aggregate_order_by
   authentication_id: order_by
-  authentication_n_allocation_aggregate: allocator_allocation_result_aggregate_order_by
-  authentication_n_market: market_factory_create_order_by
-  authentication_n_property: property_factory_create_order_by
-  authentication_n_reward_aggregate: reward_calculation_result_aggregate_order_by
   block_number: order_by
   market: order_by
+  market_creation: market_factory_create_order_by
   metrics: order_by
   property: order_by
+  property_creation: property_factory_create_order_by
+  reward_aggregate: reward_calculation_result_aggregate_order_by
 }
 
 # primary key columns input for table: "property_authentication"
@@ -5333,14 +5331,8 @@ input property_authentication_variance_order_by {
 
 # columns and relationships of "property_factory_create"
 type property_factory_create {
-  block_number: Int!
-  event_id: String!
-  from_address: String!
-  log_index: Int!
-  property: String!
-
   # An array relationship
-  property_n_allocation(
+  allocation(
     # distinct select on columns
     distinct_on: [allocator_allocation_result_select_column!]
 
@@ -5358,7 +5350,7 @@ type property_factory_create {
   ): [allocator_allocation_result!]!
 
   # An aggregated array relationship
-  property_n_allocation_aggregate(
+  allocation_aggregate(
     # distinct select on columns
     distinct_on: [allocator_allocation_result_select_column!]
 
@@ -5376,7 +5368,7 @@ type property_factory_create {
   ): allocator_allocation_result_aggregate!
 
   # An array relationship
-  property_n_authentication(
+  authentication(
     # distinct select on columns
     distinct_on: [property_authentication_select_column!]
 
@@ -5394,7 +5386,7 @@ type property_factory_create {
   ): [property_authentication!]!
 
   # An aggregated array relationship
-  property_n_authentication_aggregate(
+  authentication_aggregate(
     # distinct select on columns
     distinct_on: [property_authentication_select_column!]
 
@@ -5410,9 +5402,10 @@ type property_factory_create {
     # filter the rows returned
     where: property_authentication_bool_exp
   ): property_authentication_aggregate!
+  block_number: Int!
 
   # An array relationship
-  property_n_authentication_deleted(
+  deleted_authentication(
     # distinct select on columns
     distinct_on: [property_authentication_deleted_select_column!]
 
@@ -5430,7 +5423,7 @@ type property_factory_create {
   ): [property_authentication_deleted!]!
 
   # An aggregated array relationship
-  property_n_authentication_deleted_aggregate(
+  deleted_authentication_aggregate(
     # distinct select on columns
     distinct_on: [property_authentication_deleted_select_column!]
 
@@ -5446,9 +5439,13 @@ type property_factory_create {
     # filter the rows returned
     where: property_authentication_deleted_bool_exp
   ): property_authentication_deleted_aggregate!
+  event_id: String!
+  from_address: String!
+  log_index: Int!
+  property: String!
 
   # An array relationship
-  property_n_lockup(
+  property_creation(
     # distinct select on columns
     distinct_on: [lockup_lockedup_select_column!]
 
@@ -5466,7 +5463,7 @@ type property_factory_create {
   ): [lockup_lockedup!]!
 
   # An aggregated array relationship
-  property_n_lockup_aggregate(
+  property_creation_aggregate(
     # distinct select on columns
     distinct_on: [lockup_lockedup_select_column!]
 
@@ -5547,15 +5544,15 @@ input property_factory_create_bool_exp {
   _and: [property_factory_create_bool_exp]
   _not: property_factory_create_bool_exp
   _or: [property_factory_create_bool_exp]
+  allocation: allocator_allocation_result_bool_exp
+  authentication: property_authentication_bool_exp
   block_number: Int_comparison_exp
+  deleted_authentication: property_authentication_deleted_bool_exp
   event_id: String_comparison_exp
   from_address: String_comparison_exp
   log_index: Int_comparison_exp
   property: String_comparison_exp
-  property_n_allocation: allocator_allocation_result_bool_exp
-  property_n_authentication: property_authentication_bool_exp
-  property_n_authentication_deleted: property_authentication_deleted_bool_exp
-  property_n_lockup: lockup_lockedup_bool_exp
+  property_creation: lockup_lockedup_bool_exp
   raw_data: String_comparison_exp
   transaction_index: Int_comparison_exp
 }
@@ -5575,15 +5572,15 @@ input property_factory_create_inc_input {
 
 # input type for inserting data into table "property_factory_create"
 input property_factory_create_insert_input {
+  allocation: allocator_allocation_result_arr_rel_insert_input
+  authentication: property_authentication_arr_rel_insert_input
   block_number: Int
+  deleted_authentication: property_authentication_deleted_arr_rel_insert_input
   event_id: String
   from_address: String
   log_index: Int
   property: String
-  property_n_allocation: allocator_allocation_result_arr_rel_insert_input
-  property_n_authentication: property_authentication_arr_rel_insert_input
-  property_n_authentication_deleted: property_authentication_deleted_arr_rel_insert_input
-  property_n_lockup: lockup_lockedup_arr_rel_insert_input
+  property_creation: lockup_lockedup_arr_rel_insert_input
   raw_data: String
   transaction_index: Int
 }
@@ -5656,15 +5653,15 @@ input property_factory_create_on_conflict {
 
 # ordering options when selecting data from "property_factory_create"
 input property_factory_create_order_by {
+  allocation_aggregate: allocator_allocation_result_aggregate_order_by
+  authentication_aggregate: property_authentication_aggregate_order_by
   block_number: order_by
+  deleted_authentication_aggregate: property_authentication_deleted_aggregate_order_by
   event_id: order_by
   from_address: order_by
   log_index: order_by
   property: order_by
-  property_n_allocation_aggregate: allocator_allocation_result_aggregate_order_by
-  property_n_authentication_aggregate: property_authentication_aggregate_order_by
-  property_n_authentication_deleted_aggregate: property_authentication_deleted_aggregate_order_by
-  property_n_lockup_aggregate: lockup_lockedup_aggregate_order_by
+  property_creation_aggregate: lockup_lockedup_aggregate_order_by
   raw_data: order_by
   transaction_index: order_by
 }
@@ -6338,24 +6335,24 @@ type query_root {
 # columns and relationships of "reward_calculation_result"
 type reward_calculation_result {
   allocate_result: numeric!
+
+  # An object relationship
+  allocation: allocator_allocation_result
   alocator_allocation_result_event_id: String!
+
+  # An object relationship
+  authentication: property_authentication
   block_number: Int!
   holder_reward: numeric!
   lockup: numeric!
   metrics: String!
+
+  # An object relationship
+  metrics_creation: metrics_factory_create
   policy: String!
 
   # An object relationship
-  reward_n_allocation: allocator_allocation_result
-
-  # An object relationship
-  reward_n_authentication: property_authentication
-
-  # An object relationship
-  reward_n_metrics: metrics_factory_create
-
-  # An object relationship
-  reward_n_policy: policy_factory_create
+  policy_creation: policy_factory_create
   staking_reward: numeric!
 }
 
@@ -6425,16 +6422,16 @@ input reward_calculation_result_bool_exp {
   _not: reward_calculation_result_bool_exp
   _or: [reward_calculation_result_bool_exp]
   allocate_result: numeric_comparison_exp
+  allocation: allocator_allocation_result_bool_exp
   alocator_allocation_result_event_id: String_comparison_exp
+  authentication: property_authentication_bool_exp
   block_number: Int_comparison_exp
   holder_reward: numeric_comparison_exp
   lockup: numeric_comparison_exp
   metrics: String_comparison_exp
+  metrics_creation: metrics_factory_create_bool_exp
   policy: String_comparison_exp
-  reward_n_allocation: allocator_allocation_result_bool_exp
-  reward_n_authentication: property_authentication_bool_exp
-  reward_n_metrics: metrics_factory_create_bool_exp
-  reward_n_policy: policy_factory_create_bool_exp
+  policy_creation: policy_factory_create_bool_exp
   staking_reward: numeric_comparison_exp
 }
 
@@ -6456,16 +6453,16 @@ input reward_calculation_result_inc_input {
 # input type for inserting data into table "reward_calculation_result"
 input reward_calculation_result_insert_input {
   allocate_result: numeric
+  allocation: allocator_allocation_result_obj_rel_insert_input
   alocator_allocation_result_event_id: String
+  authentication: property_authentication_obj_rel_insert_input
   block_number: Int
   holder_reward: numeric
   lockup: numeric
   metrics: String
+  metrics_creation: metrics_factory_create_obj_rel_insert_input
   policy: String
-  reward_n_allocation: allocator_allocation_result_obj_rel_insert_input
-  reward_n_authentication: property_authentication_obj_rel_insert_input
-  reward_n_metrics: metrics_factory_create_obj_rel_insert_input
-  reward_n_policy: policy_factory_create_obj_rel_insert_input
+  policy_creation: policy_factory_create_obj_rel_insert_input
   staking_reward: numeric
 }
 
@@ -6542,16 +6539,16 @@ input reward_calculation_result_on_conflict {
 # ordering options when selecting data from "reward_calculation_result"
 input reward_calculation_result_order_by {
   allocate_result: order_by
+  allocation: allocator_allocation_result_order_by
   alocator_allocation_result_event_id: order_by
+  authentication: property_authentication_order_by
   block_number: order_by
   holder_reward: order_by
   lockup: order_by
   metrics: order_by
+  metrics_creation: metrics_factory_create_order_by
   policy: order_by
-  reward_n_allocation: allocator_allocation_result_order_by
-  reward_n_authentication: property_authentication_order_by
-  reward_n_metrics: metrics_factory_create_order_by
-  reward_n_policy: policy_factory_create_order_by
+  policy_creation: policy_factory_create_order_by
   staking_reward: order_by
 }
 

--- a/packages/graphql/src/scheme.graphql
+++ b/packages/graphql/src/scheme.graphql
@@ -6,6 +6,14 @@ schema {
 
 # columns and relationships of "allocator_allocation_result"
 type allocator_allocation_result {
+  # An object relationship
+  allocation_n_authentication: property_authentication
+
+  # An object relationship
+  allocation_n_property: property_factory_create
+
+  # An object relationship
+  allocation_n_reward: reward_calculation_result
   arg_value: numeric!
   block_number: Int!
   event_id: String!
@@ -87,6 +95,9 @@ input allocator_allocation_result_bool_exp {
   _and: [allocator_allocation_result_bool_exp]
   _not: allocator_allocation_result_bool_exp
   _or: [allocator_allocation_result_bool_exp]
+  allocation_n_authentication: property_authentication_bool_exp
+  allocation_n_property: property_factory_create_bool_exp
+  allocation_n_reward: reward_calculation_result_bool_exp
   arg_value: numeric_comparison_exp
   block_number: Int_comparison_exp
   event_id: String_comparison_exp
@@ -106,15 +117,21 @@ enum allocator_allocation_result_constraint {
   allocator_allocation_result_pkey
 }
 
-# input type for incrementing integer columne in table "allocator_allocation_result"
+# input type for incrementing integer column in table "allocator_allocation_result"
 input allocator_allocation_result_inc_input {
+  arg_value: numeric
   block_number: Int
+  lockup_value: numeric
   log_index: Int
+  result: numeric
   transaction_index: Int
 }
 
 # input type for inserting data into table "allocator_allocation_result"
 input allocator_allocation_result_insert_input {
+  allocation_n_authentication: property_authentication_obj_rel_insert_input
+  allocation_n_property: property_factory_create_obj_rel_insert_input
+  allocation_n_reward: reward_calculation_result_obj_rel_insert_input
   arg_value: numeric
   block_number: Int
   event_id: String
@@ -212,6 +229,9 @@ input allocator_allocation_result_on_conflict {
 
 # ordering options when selecting data from "allocator_allocation_result"
 input allocator_allocation_result_order_by {
+  allocation_n_authentication: property_authentication_order_by
+  allocation_n_property: property_factory_create_order_by
+  allocation_n_reward: reward_calculation_result_order_by
   arg_value: order_by
   block_number: order_by
   event_id: order_by
@@ -223,6 +243,11 @@ input allocator_allocation_result_order_by {
   raw_data: order_by
   result: order_by
   transaction_index: order_by
+}
+
+# primary key columns input for table: "allocator_allocation_result"
+input allocator_allocation_result_pk_columns_input {
+  event_id: String!
 }
 
 # select columns of table "allocator_allocation_result"
@@ -560,10 +585,16 @@ enum allocator_before_allocation_constraint {
   allocator_before_allocation_pkey
 }
 
-# input type for incrementing integer columne in table "allocator_before_allocation"
+# input type for incrementing integer column in table "allocator_before_allocation"
 input allocator_before_allocation_inc_input {
+  assets: numeric
   block_number: Int
+  blocks: numeric
   log_index: Int
+  market_value: numeric
+  mint: numeric
+  token_value: numeric
+  total_assets: numeric
   transaction_index: Int
 }
 
@@ -677,6 +708,11 @@ input allocator_before_allocation_order_by {
   token_value: order_by
   total_assets: order_by
   transaction_index: order_by
+}
+
+# primary key columns input for table: "allocator_before_allocation"
+input allocator_before_allocation_pk_columns_input {
+  event_id: String!
 }
 
 # select columns of table "allocator_before_allocation"
@@ -1009,6 +1045,45 @@ type lockup_lockedup {
   block_number: Int!
   event_id: String!
   from_address: String!
+
+  # An array relationship
+  lockup_n_allocation(
+    # distinct select on columns
+    distinct_on: [allocator_allocation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [allocator_allocation_result_order_by!]
+
+    # filter the rows returned
+    where: allocator_allocation_result_bool_exp
+  ): [allocator_allocation_result!]!
+
+  # An aggregated array relationship
+  lockup_n_allocation_aggregate(
+    # distinct select on columns
+    distinct_on: [allocator_allocation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [allocator_allocation_result_order_by!]
+
+    # filter the rows returned
+    where: allocator_allocation_result_bool_exp
+  ): allocator_allocation_result_aggregate!
+
+  # An object relationship
+  lockup_n_property: property_factory_create
   log_index: Int!
   property: String!
   raw_data: String!
@@ -1082,6 +1157,8 @@ input lockup_lockedup_bool_exp {
   block_number: Int_comparison_exp
   event_id: String_comparison_exp
   from_address: String_comparison_exp
+  lockup_n_allocation: allocator_allocation_result_bool_exp
+  lockup_n_property: property_factory_create_bool_exp
   log_index: Int_comparison_exp
   property: String_comparison_exp
   raw_data: String_comparison_exp
@@ -1095,10 +1172,11 @@ enum lockup_lockedup_constraint {
   lockup_lockedup_pkey
 }
 
-# input type for incrementing integer columne in table "lockup_lockedup"
+# input type for incrementing integer column in table "lockup_lockedup"
 input lockup_lockedup_inc_input {
   block_number: Int
   log_index: Int
+  token_value: numeric
   transaction_index: Int
 }
 
@@ -1107,6 +1185,8 @@ input lockup_lockedup_insert_input {
   block_number: Int
   event_id: String
   from_address: String
+  lockup_n_allocation: allocator_allocation_result_arr_rel_insert_input
+  lockup_n_property: property_factory_create_obj_rel_insert_input
   log_index: Int
   property: String
   raw_data: String
@@ -1189,11 +1269,18 @@ input lockup_lockedup_order_by {
   block_number: order_by
   event_id: order_by
   from_address: order_by
+  lockup_n_allocation_aggregate: allocator_allocation_result_aggregate_order_by
+  lockup_n_property: property_factory_create_order_by
   log_index: order_by
   property: order_by
   raw_data: order_by
   token_value: order_by
   transaction_index: order_by
+}
+
+# primary key columns input for table: "lockup_lockedup"
+input lockup_lockedup_pk_columns_input {
+  event_id: String!
 }
 
 # select columns of table "lockup_lockedup"
@@ -1381,6 +1468,114 @@ type market_factory_create {
   from_address: String!
   log_index: Int!
   market: String!
+
+  # An array relationship
+  market_n_allocation(
+    # distinct select on columns
+    distinct_on: [allocator_allocation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [allocator_allocation_result_order_by!]
+
+    # filter the rows returned
+    where: allocator_allocation_result_bool_exp
+  ): [allocator_allocation_result!]!
+
+  # An aggregated array relationship
+  market_n_allocation_aggregate(
+    # distinct select on columns
+    distinct_on: [allocator_allocation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [allocator_allocation_result_order_by!]
+
+    # filter the rows returned
+    where: allocator_allocation_result_bool_exp
+  ): allocator_allocation_result_aggregate!
+
+  # An array relationship
+  market_n_metrics(
+    # distinct select on columns
+    distinct_on: [metrics_factory_create_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [metrics_factory_create_order_by!]
+
+    # filter the rows returned
+    where: metrics_factory_create_bool_exp
+  ): [metrics_factory_create!]!
+
+  # An aggregated array relationship
+  market_n_metrics_aggregate(
+    # distinct select on columns
+    distinct_on: [metrics_factory_create_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [metrics_factory_create_order_by!]
+
+    # filter the rows returned
+    where: metrics_factory_create_bool_exp
+  ): metrics_factory_create_aggregate!
+
+  # An array relationship
+  market_n_metrics_destroy(
+    # distinct select on columns
+    distinct_on: [metrics_factory_destroy_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [metrics_factory_destroy_order_by!]
+
+    # filter the rows returned
+    where: metrics_factory_destroy_bool_exp
+  ): [metrics_factory_destroy!]!
+
+  # An aggregated array relationship
+  market_n_metrics_destroy_aggregate(
+    # distinct select on columns
+    distinct_on: [metrics_factory_destroy_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [metrics_factory_destroy_order_by!]
+
+    # filter the rows returned
+    where: metrics_factory_destroy_bool_exp
+  ): metrics_factory_destroy_aggregate!
   raw_data: String!
   transaction_index: Int!
 }
@@ -1451,6 +1646,9 @@ input market_factory_create_bool_exp {
   from_address: String_comparison_exp
   log_index: Int_comparison_exp
   market: String_comparison_exp
+  market_n_allocation: allocator_allocation_result_bool_exp
+  market_n_metrics: metrics_factory_create_bool_exp
+  market_n_metrics_destroy: metrics_factory_destroy_bool_exp
   raw_data: String_comparison_exp
   transaction_index: Int_comparison_exp
 }
@@ -1461,7 +1659,7 @@ enum market_factory_create_constraint {
   market_factory_create_pkey
 }
 
-# input type for incrementing integer columne in table "market_factory_create"
+# input type for incrementing integer column in table "market_factory_create"
 input market_factory_create_inc_input {
   block_number: Int
   log_index: Int
@@ -1475,6 +1673,9 @@ input market_factory_create_insert_input {
   from_address: String
   log_index: Int
   market: String
+  market_n_allocation: allocator_allocation_result_arr_rel_insert_input
+  market_n_metrics: metrics_factory_create_arr_rel_insert_input
+  market_n_metrics_destroy: metrics_factory_destroy_arr_rel_insert_input
   raw_data: String
   transaction_index: Int
 }
@@ -1552,8 +1753,16 @@ input market_factory_create_order_by {
   from_address: order_by
   log_index: order_by
   market: order_by
+  market_n_allocation_aggregate: allocator_allocation_result_aggregate_order_by
+  market_n_metrics_aggregate: metrics_factory_create_aggregate_order_by
+  market_n_metrics_destroy_aggregate: metrics_factory_destroy_aggregate_order_by
   raw_data: order_by
   transaction_index: order_by
+}
+
+# primary key columns input for table: "market_factory_create"
+input market_factory_create_pk_columns_input {
+  event_id: String!
 }
 
 # select columns of table "market_factory_create"
@@ -1720,6 +1929,12 @@ type metrics_factory_create {
   from_address: String!
   log_index: Int!
   metrics: String!
+
+  # An object relationship
+  metrics_n_market: market_factory_create
+
+  # An object relationship
+  metrics_n_metrics_destroy: metrics_factory_destroy
   raw_data: String!
   transaction_index: Int!
 }
@@ -1790,6 +2005,8 @@ input metrics_factory_create_bool_exp {
   from_address: String_comparison_exp
   log_index: Int_comparison_exp
   metrics: String_comparison_exp
+  metrics_n_market: market_factory_create_bool_exp
+  metrics_n_metrics_destroy: metrics_factory_destroy_bool_exp
   raw_data: String_comparison_exp
   transaction_index: Int_comparison_exp
 }
@@ -1800,7 +2017,7 @@ enum metrics_factory_create_constraint {
   metrics_factory_create_pkey
 }
 
-# input type for incrementing integer columne in table "metrics_factory_create"
+# input type for incrementing integer column in table "metrics_factory_create"
 input metrics_factory_create_inc_input {
   block_number: Int
   log_index: Int
@@ -1814,6 +2031,8 @@ input metrics_factory_create_insert_input {
   from_address: String
   log_index: Int
   metrics: String
+  metrics_n_market: market_factory_create_obj_rel_insert_input
+  metrics_n_metrics_destroy: metrics_factory_destroy_obj_rel_insert_input
   raw_data: String
   transaction_index: Int
 }
@@ -1891,8 +2110,15 @@ input metrics_factory_create_order_by {
   from_address: order_by
   log_index: order_by
   metrics: order_by
+  metrics_n_market: market_factory_create_order_by
+  metrics_n_metrics_destroy: metrics_factory_destroy_order_by
   raw_data: order_by
   transaction_index: order_by
+}
+
+# primary key columns input for table: "metrics_factory_create"
+input metrics_factory_create_pk_columns_input {
+  event_id: String!
 }
 
 # select columns of table "metrics_factory_create"
@@ -2059,6 +2285,12 @@ type metrics_factory_destroy {
   from_address: String!
   log_index: Int!
   metrics: String!
+
+  # An object relationship
+  metrics_destroy_n_market: market_factory_create
+
+  # An object relationship
+  metrics_destroy_n_metrics: metrics_factory_create
   raw_data: String!
   transaction_index: Int!
 }
@@ -2129,6 +2361,8 @@ input metrics_factory_destroy_bool_exp {
   from_address: String_comparison_exp
   log_index: Int_comparison_exp
   metrics: String_comparison_exp
+  metrics_destroy_n_market: market_factory_create_bool_exp
+  metrics_destroy_n_metrics: metrics_factory_create_bool_exp
   raw_data: String_comparison_exp
   transaction_index: Int_comparison_exp
 }
@@ -2139,7 +2373,7 @@ enum metrics_factory_destroy_constraint {
   metrics_factory_destroy_pkey
 }
 
-# input type for incrementing integer columne in table "metrics_factory_destroy"
+# input type for incrementing integer column in table "metrics_factory_destroy"
 input metrics_factory_destroy_inc_input {
   block_number: Int
   log_index: Int
@@ -2153,6 +2387,8 @@ input metrics_factory_destroy_insert_input {
   from_address: String
   log_index: Int
   metrics: String
+  metrics_destroy_n_market: market_factory_create_obj_rel_insert_input
+  metrics_destroy_n_metrics: metrics_factory_create_obj_rel_insert_input
   raw_data: String
   transaction_index: Int
 }
@@ -2230,8 +2466,15 @@ input metrics_factory_destroy_order_by {
   from_address: order_by
   log_index: order_by
   metrics: order_by
+  metrics_destroy_n_market: market_factory_create_order_by
+  metrics_destroy_n_metrics: metrics_factory_create_order_by
   raw_data: order_by
   transaction_index: order_by
+}
+
+# primary key columns input for table: "metrics_factory_destroy"
+input metrics_factory_destroy_pk_columns_input {
+  event_id: String!
 }
 
 # select columns of table "metrics_factory_destroy"
@@ -2399,11 +2642,17 @@ type mutation_root {
     where: allocator_allocation_result_bool_exp!
   ): allocator_allocation_result_mutation_response
 
+  # delete single row from the table: "allocator_allocation_result"
+  delete_allocator_allocation_result_by_pk(event_id: String!): allocator_allocation_result
+
   # delete data from the table: "allocator_before_allocation"
   delete_allocator_before_allocation(
     # filter the rows which have to be deleted
     where: allocator_before_allocation_bool_exp!
   ): allocator_before_allocation_mutation_response
+
+  # delete single row from the table: "allocator_before_allocation"
+  delete_allocator_before_allocation_by_pk(event_id: String!): allocator_before_allocation
 
   # delete data from the table: "lockup_lockedup"
   delete_lockup_lockedup(
@@ -2411,11 +2660,17 @@ type mutation_root {
     where: lockup_lockedup_bool_exp!
   ): lockup_lockedup_mutation_response
 
+  # delete single row from the table: "lockup_lockedup"
+  delete_lockup_lockedup_by_pk(event_id: String!): lockup_lockedup
+
   # delete data from the table: "market_factory_create"
   delete_market_factory_create(
     # filter the rows which have to be deleted
     where: market_factory_create_bool_exp!
   ): market_factory_create_mutation_response
+
+  # delete single row from the table: "market_factory_create"
+  delete_market_factory_create_by_pk(event_id: String!): market_factory_create
 
   # delete data from the table: "metrics_factory_create"
   delete_metrics_factory_create(
@@ -2423,11 +2678,17 @@ type mutation_root {
     where: metrics_factory_create_bool_exp!
   ): metrics_factory_create_mutation_response
 
+  # delete single row from the table: "metrics_factory_create"
+  delete_metrics_factory_create_by_pk(event_id: String!): metrics_factory_create
+
   # delete data from the table: "metrics_factory_destroy"
   delete_metrics_factory_destroy(
     # filter the rows which have to be deleted
     where: metrics_factory_destroy_bool_exp!
   ): metrics_factory_destroy_mutation_response
+
+  # delete single row from the table: "metrics_factory_destroy"
+  delete_metrics_factory_destroy_by_pk(event_id: String!): metrics_factory_destroy
 
   # delete data from the table: "policy_factory_create"
   delete_policy_factory_create(
@@ -2435,11 +2696,17 @@ type mutation_root {
     where: policy_factory_create_bool_exp!
   ): policy_factory_create_mutation_response
 
+  # delete single row from the table: "policy_factory_create"
+  delete_policy_factory_create_by_pk(event_id: String!): policy_factory_create
+
   # delete data from the table: "property_authentication"
   delete_property_authentication(
     # filter the rows which have to be deleted
     where: property_authentication_bool_exp!
   ): property_authentication_mutation_response
+
+  # delete single row from the table: "property_authentication"
+  delete_property_authentication_by_pk(metrics: String!, property: String!): property_authentication
 
   # delete data from the table: "property_authentication_deleted"
   delete_property_authentication_deleted(
@@ -2447,17 +2714,26 @@ type mutation_root {
     where: property_authentication_deleted_bool_exp!
   ): property_authentication_deleted_mutation_response
 
+  # delete single row from the table: "property_authentication_deleted"
+  delete_property_authentication_deleted_by_pk(metrics: String!, property: String!): property_authentication_deleted
+
   # delete data from the table: "property_factory_create"
   delete_property_factory_create(
     # filter the rows which have to be deleted
     where: property_factory_create_bool_exp!
   ): property_factory_create_mutation_response
 
+  # delete single row from the table: "property_factory_create"
+  delete_property_factory_create_by_pk(event_id: String!): property_factory_create
+
   # delete data from the table: "reward_calculation_result"
   delete_reward_calculation_result(
     # filter the rows which have to be deleted
     where: reward_calculation_result_bool_exp!
   ): reward_calculation_result_mutation_response
+
+  # delete single row from the table: "reward_calculation_result"
+  delete_reward_calculation_result_by_pk(alocator_allocation_result_event_id: String!): reward_calculation_result
 
   # insert data into the table: "allocator_allocation_result"
   insert_allocator_allocation_result(
@@ -2468,6 +2744,15 @@ type mutation_root {
     on_conflict: allocator_allocation_result_on_conflict
   ): allocator_allocation_result_mutation_response
 
+  # insert a single row into the table: "allocator_allocation_result"
+  insert_allocator_allocation_result_one(
+    # the row to be inserted
+    object: allocator_allocation_result_insert_input!
+
+    # on conflict condition
+    on_conflict: allocator_allocation_result_on_conflict
+  ): allocator_allocation_result
+
   # insert data into the table: "allocator_before_allocation"
   insert_allocator_before_allocation(
     # the rows to be inserted
@@ -2476,6 +2761,15 @@ type mutation_root {
     # on conflict condition
     on_conflict: allocator_before_allocation_on_conflict
   ): allocator_before_allocation_mutation_response
+
+  # insert a single row into the table: "allocator_before_allocation"
+  insert_allocator_before_allocation_one(
+    # the row to be inserted
+    object: allocator_before_allocation_insert_input!
+
+    # on conflict condition
+    on_conflict: allocator_before_allocation_on_conflict
+  ): allocator_before_allocation
 
   # insert data into the table: "lockup_lockedup"
   insert_lockup_lockedup(
@@ -2486,6 +2780,15 @@ type mutation_root {
     on_conflict: lockup_lockedup_on_conflict
   ): lockup_lockedup_mutation_response
 
+  # insert a single row into the table: "lockup_lockedup"
+  insert_lockup_lockedup_one(
+    # the row to be inserted
+    object: lockup_lockedup_insert_input!
+
+    # on conflict condition
+    on_conflict: lockup_lockedup_on_conflict
+  ): lockup_lockedup
+
   # insert data into the table: "market_factory_create"
   insert_market_factory_create(
     # the rows to be inserted
@@ -2494,6 +2797,15 @@ type mutation_root {
     # on conflict condition
     on_conflict: market_factory_create_on_conflict
   ): market_factory_create_mutation_response
+
+  # insert a single row into the table: "market_factory_create"
+  insert_market_factory_create_one(
+    # the row to be inserted
+    object: market_factory_create_insert_input!
+
+    # on conflict condition
+    on_conflict: market_factory_create_on_conflict
+  ): market_factory_create
 
   # insert data into the table: "metrics_factory_create"
   insert_metrics_factory_create(
@@ -2504,6 +2816,15 @@ type mutation_root {
     on_conflict: metrics_factory_create_on_conflict
   ): metrics_factory_create_mutation_response
 
+  # insert a single row into the table: "metrics_factory_create"
+  insert_metrics_factory_create_one(
+    # the row to be inserted
+    object: metrics_factory_create_insert_input!
+
+    # on conflict condition
+    on_conflict: metrics_factory_create_on_conflict
+  ): metrics_factory_create
+
   # insert data into the table: "metrics_factory_destroy"
   insert_metrics_factory_destroy(
     # the rows to be inserted
@@ -2513,6 +2834,15 @@ type mutation_root {
     on_conflict: metrics_factory_destroy_on_conflict
   ): metrics_factory_destroy_mutation_response
 
+  # insert a single row into the table: "metrics_factory_destroy"
+  insert_metrics_factory_destroy_one(
+    # the row to be inserted
+    object: metrics_factory_destroy_insert_input!
+
+    # on conflict condition
+    on_conflict: metrics_factory_destroy_on_conflict
+  ): metrics_factory_destroy
+
   # insert data into the table: "policy_factory_create"
   insert_policy_factory_create(
     # the rows to be inserted
@@ -2521,6 +2851,15 @@ type mutation_root {
     # on conflict condition
     on_conflict: policy_factory_create_on_conflict
   ): policy_factory_create_mutation_response
+
+  # insert a single row into the table: "policy_factory_create"
+  insert_policy_factory_create_one(
+    # the row to be inserted
+    object: policy_factory_create_insert_input!
+
+    # on conflict condition
+    on_conflict: policy_factory_create_on_conflict
+  ): policy_factory_create
 
   # insert data into the table: "property_authentication"
   insert_property_authentication(
@@ -2540,6 +2879,24 @@ type mutation_root {
     on_conflict: property_authentication_deleted_on_conflict
   ): property_authentication_deleted_mutation_response
 
+  # insert a single row into the table: "property_authentication_deleted"
+  insert_property_authentication_deleted_one(
+    # the row to be inserted
+    object: property_authentication_deleted_insert_input!
+
+    # on conflict condition
+    on_conflict: property_authentication_deleted_on_conflict
+  ): property_authentication_deleted
+
+  # insert a single row into the table: "property_authentication"
+  insert_property_authentication_one(
+    # the row to be inserted
+    object: property_authentication_insert_input!
+
+    # on conflict condition
+    on_conflict: property_authentication_on_conflict
+  ): property_authentication
+
   # insert data into the table: "property_factory_create"
   insert_property_factory_create(
     # the rows to be inserted
@@ -2549,6 +2906,15 @@ type mutation_root {
     on_conflict: property_factory_create_on_conflict
   ): property_factory_create_mutation_response
 
+  # insert a single row into the table: "property_factory_create"
+  insert_property_factory_create_one(
+    # the row to be inserted
+    object: property_factory_create_insert_input!
+
+    # on conflict condition
+    on_conflict: property_factory_create_on_conflict
+  ): property_factory_create
+
   # insert data into the table: "reward_calculation_result"
   insert_reward_calculation_result(
     # the rows to be inserted
@@ -2557,6 +2923,15 @@ type mutation_root {
     # on conflict condition
     on_conflict: reward_calculation_result_on_conflict
   ): reward_calculation_result_mutation_response
+
+  # insert a single row into the table: "reward_calculation_result"
+  insert_reward_calculation_result_one(
+    # the row to be inserted
+    object: reward_calculation_result_insert_input!
+
+    # on conflict condition
+    on_conflict: reward_calculation_result_on_conflict
+  ): reward_calculation_result
 
   # update data of the table: "allocator_allocation_result"
   update_allocator_allocation_result(
@@ -2570,6 +2945,16 @@ type mutation_root {
     where: allocator_allocation_result_bool_exp!
   ): allocator_allocation_result_mutation_response
 
+  # update single row of the table: "allocator_allocation_result"
+  update_allocator_allocation_result_by_pk(
+    # increments the integer columns with given value of the filtered values
+    _inc: allocator_allocation_result_inc_input
+
+    # sets the columns of the filtered rows to the given values
+    _set: allocator_allocation_result_set_input
+    pk_columns: allocator_allocation_result_pk_columns_input!
+  ): allocator_allocation_result
+
   # update data of the table: "allocator_before_allocation"
   update_allocator_before_allocation(
     # increments the integer columns with given value of the filtered values
@@ -2581,6 +2966,16 @@ type mutation_root {
     # filter the rows which have to be updated
     where: allocator_before_allocation_bool_exp!
   ): allocator_before_allocation_mutation_response
+
+  # update single row of the table: "allocator_before_allocation"
+  update_allocator_before_allocation_by_pk(
+    # increments the integer columns with given value of the filtered values
+    _inc: allocator_before_allocation_inc_input
+
+    # sets the columns of the filtered rows to the given values
+    _set: allocator_before_allocation_set_input
+    pk_columns: allocator_before_allocation_pk_columns_input!
+  ): allocator_before_allocation
 
   # update data of the table: "lockup_lockedup"
   update_lockup_lockedup(
@@ -2594,6 +2989,16 @@ type mutation_root {
     where: lockup_lockedup_bool_exp!
   ): lockup_lockedup_mutation_response
 
+  # update single row of the table: "lockup_lockedup"
+  update_lockup_lockedup_by_pk(
+    # increments the integer columns with given value of the filtered values
+    _inc: lockup_lockedup_inc_input
+
+    # sets the columns of the filtered rows to the given values
+    _set: lockup_lockedup_set_input
+    pk_columns: lockup_lockedup_pk_columns_input!
+  ): lockup_lockedup
+
   # update data of the table: "market_factory_create"
   update_market_factory_create(
     # increments the integer columns with given value of the filtered values
@@ -2605,6 +3010,16 @@ type mutation_root {
     # filter the rows which have to be updated
     where: market_factory_create_bool_exp!
   ): market_factory_create_mutation_response
+
+  # update single row of the table: "market_factory_create"
+  update_market_factory_create_by_pk(
+    # increments the integer columns with given value of the filtered values
+    _inc: market_factory_create_inc_input
+
+    # sets the columns of the filtered rows to the given values
+    _set: market_factory_create_set_input
+    pk_columns: market_factory_create_pk_columns_input!
+  ): market_factory_create
 
   # update data of the table: "metrics_factory_create"
   update_metrics_factory_create(
@@ -2618,6 +3033,16 @@ type mutation_root {
     where: metrics_factory_create_bool_exp!
   ): metrics_factory_create_mutation_response
 
+  # update single row of the table: "metrics_factory_create"
+  update_metrics_factory_create_by_pk(
+    # increments the integer columns with given value of the filtered values
+    _inc: metrics_factory_create_inc_input
+
+    # sets the columns of the filtered rows to the given values
+    _set: metrics_factory_create_set_input
+    pk_columns: metrics_factory_create_pk_columns_input!
+  ): metrics_factory_create
+
   # update data of the table: "metrics_factory_destroy"
   update_metrics_factory_destroy(
     # increments the integer columns with given value of the filtered values
@@ -2629,6 +3054,16 @@ type mutation_root {
     # filter the rows which have to be updated
     where: metrics_factory_destroy_bool_exp!
   ): metrics_factory_destroy_mutation_response
+
+  # update single row of the table: "metrics_factory_destroy"
+  update_metrics_factory_destroy_by_pk(
+    # increments the integer columns with given value of the filtered values
+    _inc: metrics_factory_destroy_inc_input
+
+    # sets the columns of the filtered rows to the given values
+    _set: metrics_factory_destroy_set_input
+    pk_columns: metrics_factory_destroy_pk_columns_input!
+  ): metrics_factory_destroy
 
   # update data of the table: "policy_factory_create"
   update_policy_factory_create(
@@ -2642,6 +3077,16 @@ type mutation_root {
     where: policy_factory_create_bool_exp!
   ): policy_factory_create_mutation_response
 
+  # update single row of the table: "policy_factory_create"
+  update_policy_factory_create_by_pk(
+    # increments the integer columns with given value of the filtered values
+    _inc: policy_factory_create_inc_input
+
+    # sets the columns of the filtered rows to the given values
+    _set: policy_factory_create_set_input
+    pk_columns: policy_factory_create_pk_columns_input!
+  ): policy_factory_create
+
   # update data of the table: "property_authentication"
   update_property_authentication(
     # increments the integer columns with given value of the filtered values
@@ -2653,6 +3098,16 @@ type mutation_root {
     # filter the rows which have to be updated
     where: property_authentication_bool_exp!
   ): property_authentication_mutation_response
+
+  # update single row of the table: "property_authentication"
+  update_property_authentication_by_pk(
+    # increments the integer columns with given value of the filtered values
+    _inc: property_authentication_inc_input
+
+    # sets the columns of the filtered rows to the given values
+    _set: property_authentication_set_input
+    pk_columns: property_authentication_pk_columns_input!
+  ): property_authentication
 
   # update data of the table: "property_authentication_deleted"
   update_property_authentication_deleted(
@@ -2666,6 +3121,16 @@ type mutation_root {
     where: property_authentication_deleted_bool_exp!
   ): property_authentication_deleted_mutation_response
 
+  # update single row of the table: "property_authentication_deleted"
+  update_property_authentication_deleted_by_pk(
+    # increments the integer columns with given value of the filtered values
+    _inc: property_authentication_deleted_inc_input
+
+    # sets the columns of the filtered rows to the given values
+    _set: property_authentication_deleted_set_input
+    pk_columns: property_authentication_deleted_pk_columns_input!
+  ): property_authentication_deleted
+
   # update data of the table: "property_factory_create"
   update_property_factory_create(
     # increments the integer columns with given value of the filtered values
@@ -2678,6 +3143,16 @@ type mutation_root {
     where: property_factory_create_bool_exp!
   ): property_factory_create_mutation_response
 
+  # update single row of the table: "property_factory_create"
+  update_property_factory_create_by_pk(
+    # increments the integer columns with given value of the filtered values
+    _inc: property_factory_create_inc_input
+
+    # sets the columns of the filtered rows to the given values
+    _set: property_factory_create_set_input
+    pk_columns: property_factory_create_pk_columns_input!
+  ): property_factory_create
+
   # update data of the table: "reward_calculation_result"
   update_reward_calculation_result(
     # increments the integer columns with given value of the filtered values
@@ -2689,6 +3164,16 @@ type mutation_root {
     # filter the rows which have to be updated
     where: reward_calculation_result_bool_exp!
   ): reward_calculation_result_mutation_response
+
+  # update single row of the table: "reward_calculation_result"
+  update_reward_calculation_result_by_pk(
+    # increments the integer columns with given value of the filtered values
+    _inc: reward_calculation_result_inc_input
+
+    # sets the columns of the filtered rows to the given values
+    _set: reward_calculation_result_set_input
+    pk_columns: reward_calculation_result_pk_columns_input!
+  ): reward_calculation_result
 }
 
 scalar numeric
@@ -3714,6 +4199,42 @@ type policy_factory_create {
   inner_policy: String!
   log_index: Int!
   policy_address: String!
+
+  # An array relationship
+  policy_n_reward(
+    # distinct select on columns
+    distinct_on: [reward_calculation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [reward_calculation_result_order_by!]
+
+    # filter the rows returned
+    where: reward_calculation_result_bool_exp
+  ): [reward_calculation_result!]!
+
+  # An aggregated array relationship
+  policy_n_reward_aggregate(
+    # distinct select on columns
+    distinct_on: [reward_calculation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [reward_calculation_result_order_by!]
+
+    # filter the rows returned
+    where: reward_calculation_result_bool_exp
+  ): reward_calculation_result_aggregate!
   raw_data: String!
   transaction_index: Int!
 }
@@ -3785,6 +4306,7 @@ input policy_factory_create_bool_exp {
   inner_policy: String_comparison_exp
   log_index: Int_comparison_exp
   policy_address: String_comparison_exp
+  policy_n_reward: reward_calculation_result_bool_exp
   raw_data: String_comparison_exp
   transaction_index: Int_comparison_exp
 }
@@ -3795,7 +4317,7 @@ enum policy_factory_create_constraint {
   policy_factory_create_pkey
 }
 
-# input type for incrementing integer columne in table "policy_factory_create"
+# input type for incrementing integer column in table "policy_factory_create"
 input policy_factory_create_inc_input {
   block_number: Int
   log_index: Int
@@ -3810,6 +4332,7 @@ input policy_factory_create_insert_input {
   inner_policy: String
   log_index: Int
   policy_address: String
+  policy_n_reward: reward_calculation_result_arr_rel_insert_input
   raw_data: String
   transaction_index: Int
 }
@@ -3892,8 +4415,14 @@ input policy_factory_create_order_by {
   inner_policy: order_by
   log_index: order_by
   policy_address: order_by
+  policy_n_reward_aggregate: reward_calculation_result_aggregate_order_by
   raw_data: order_by
   transaction_index: order_by
+}
+
+# primary key columns input for table: "policy_factory_create"
+input policy_factory_create_pk_columns_input {
+  event_id: String!
 }
 
 # select columns of table "policy_factory_create"
@@ -4063,6 +4592,84 @@ input policy_factory_create_variance_order_by {
 # columns and relationships of "property_authentication"
 type property_authentication {
   authentication_id: String!
+
+  # An array relationship
+  authentication_n_allocation(
+    # distinct select on columns
+    distinct_on: [allocator_allocation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [allocator_allocation_result_order_by!]
+
+    # filter the rows returned
+    where: allocator_allocation_result_bool_exp
+  ): [allocator_allocation_result!]!
+
+  # An aggregated array relationship
+  authentication_n_allocation_aggregate(
+    # distinct select on columns
+    distinct_on: [allocator_allocation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [allocator_allocation_result_order_by!]
+
+    # filter the rows returned
+    where: allocator_allocation_result_bool_exp
+  ): allocator_allocation_result_aggregate!
+
+  # An object relationship
+  authentication_n_market: market_factory_create
+
+  # An object relationship
+  authentication_n_property: property_factory_create
+
+  # An array relationship
+  authentication_n_reward(
+    # distinct select on columns
+    distinct_on: [reward_calculation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [reward_calculation_result_order_by!]
+
+    # filter the rows returned
+    where: reward_calculation_result_bool_exp
+  ): [reward_calculation_result!]!
+
+  # An aggregated array relationship
+  authentication_n_reward_aggregate(
+    # distinct select on columns
+    distinct_on: [reward_calculation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [reward_calculation_result_order_by!]
+
+    # filter the rows returned
+    where: reward_calculation_result_bool_exp
+  ): reward_calculation_result_aggregate!
   block_number: Int!
   market: String!
   metrics: String!
@@ -4127,6 +4734,10 @@ input property_authentication_bool_exp {
   _not: property_authentication_bool_exp
   _or: [property_authentication_bool_exp]
   authentication_id: String_comparison_exp
+  authentication_n_allocation: allocator_allocation_result_bool_exp
+  authentication_n_market: market_factory_create_bool_exp
+  authentication_n_property: property_factory_create_bool_exp
+  authentication_n_reward: reward_calculation_result_bool_exp
   block_number: Int_comparison_exp
   market: String_comparison_exp
   metrics: String_comparison_exp
@@ -4141,6 +4752,83 @@ enum property_authentication_constraint {
 
 # columns and relationships of "property_authentication_deleted"
 type property_authentication_deleted {
+  # An array relationship
+  authentication_deleted_n_allocation(
+    # distinct select on columns
+    distinct_on: [allocator_allocation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [allocator_allocation_result_order_by!]
+
+    # filter the rows returned
+    where: allocator_allocation_result_bool_exp
+  ): [allocator_allocation_result!]!
+
+  # An aggregated array relationship
+  authentication_deleted_n_allocation_aggregate(
+    # distinct select on columns
+    distinct_on: [allocator_allocation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [allocator_allocation_result_order_by!]
+
+    # filter the rows returned
+    where: allocator_allocation_result_bool_exp
+  ): allocator_allocation_result_aggregate!
+
+  # An object relationship
+  authentication_deleted_n_market: market_factory_create
+
+  # An object relationship
+  authentication_deleted_n_property: property_factory_create
+
+  # An array relationship
+  authentication_deleted_n_reward(
+    # distinct select on columns
+    distinct_on: [reward_calculation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [reward_calculation_result_order_by!]
+
+    # filter the rows returned
+    where: reward_calculation_result_bool_exp
+  ): [reward_calculation_result!]!
+
+  # An aggregated array relationship
+  authentication_deleted_n_reward_aggregate(
+    # distinct select on columns
+    distinct_on: [reward_calculation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [reward_calculation_result_order_by!]
+
+    # filter the rows returned
+    where: reward_calculation_result_bool_exp
+  ): reward_calculation_result_aggregate!
   authentication_id: String!
   block_number: Int!
   market: String!
@@ -4206,6 +4894,10 @@ input property_authentication_deleted_bool_exp {
   _and: [property_authentication_deleted_bool_exp]
   _not: property_authentication_deleted_bool_exp
   _or: [property_authentication_deleted_bool_exp]
+  authentication_deleted_n_allocation: allocator_allocation_result_bool_exp
+  authentication_deleted_n_market: market_factory_create_bool_exp
+  authentication_deleted_n_property: property_factory_create_bool_exp
+  authentication_deleted_n_reward: reward_calculation_result_bool_exp
   authentication_id: String_comparison_exp
   block_number: Int_comparison_exp
   market: String_comparison_exp
@@ -4219,13 +4911,17 @@ enum property_authentication_deleted_constraint {
   property_authentication_deleted_pkey
 }
 
-# input type for incrementing integer columne in table "property_authentication_deleted"
+# input type for incrementing integer column in table "property_authentication_deleted"
 input property_authentication_deleted_inc_input {
   block_number: Int
 }
 
 # input type for inserting data into table "property_authentication_deleted"
 input property_authentication_deleted_insert_input {
+  authentication_deleted_n_allocation: allocator_allocation_result_arr_rel_insert_input
+  authentication_deleted_n_market: market_factory_create_obj_rel_insert_input
+  authentication_deleted_n_property: property_factory_create_obj_rel_insert_input
+  authentication_deleted_n_reward: reward_calculation_result_arr_rel_insert_input
   authentication_id: String
   block_number: Int
   market: String
@@ -4293,11 +4989,21 @@ input property_authentication_deleted_on_conflict {
 
 # ordering options when selecting data from "property_authentication_deleted"
 input property_authentication_deleted_order_by {
+  authentication_deleted_n_allocation_aggregate: allocator_allocation_result_aggregate_order_by
+  authentication_deleted_n_market: market_factory_create_order_by
+  authentication_deleted_n_property: property_factory_create_order_by
+  authentication_deleted_n_reward_aggregate: reward_calculation_result_aggregate_order_by
   authentication_id: order_by
   block_number: order_by
   market: order_by
   metrics: order_by
   property: order_by
+}
+
+# primary key columns input for table: "property_authentication_deleted"
+input property_authentication_deleted_pk_columns_input {
+  metrics: String!
+  property: String!
 }
 
 # select columns of table "property_authentication_deleted"
@@ -4415,7 +5121,7 @@ input property_authentication_deleted_variance_order_by {
   block_number: order_by
 }
 
-# input type for incrementing integer columne in table "property_authentication"
+# input type for incrementing integer column in table "property_authentication"
 input property_authentication_inc_input {
   block_number: Int
 }
@@ -4423,6 +5129,10 @@ input property_authentication_inc_input {
 # input type for inserting data into table "property_authentication"
 input property_authentication_insert_input {
   authentication_id: String
+  authentication_n_allocation: allocator_allocation_result_arr_rel_insert_input
+  authentication_n_market: market_factory_create_obj_rel_insert_input
+  authentication_n_property: property_factory_create_obj_rel_insert_input
+  authentication_n_reward: reward_calculation_result_arr_rel_insert_input
   block_number: Int
   market: String
   metrics: String
@@ -4490,10 +5200,20 @@ input property_authentication_on_conflict {
 # ordering options when selecting data from "property_authentication"
 input property_authentication_order_by {
   authentication_id: order_by
+  authentication_n_allocation_aggregate: allocator_allocation_result_aggregate_order_by
+  authentication_n_market: market_factory_create_order_by
+  authentication_n_property: property_factory_create_order_by
+  authentication_n_reward_aggregate: reward_calculation_result_aggregate_order_by
   block_number: order_by
   market: order_by
   metrics: order_by
   property: order_by
+}
+
+# primary key columns input for table: "property_authentication"
+input property_authentication_pk_columns_input {
+  metrics: String!
+  property: String!
 }
 
 # select columns of table "property_authentication"
@@ -4618,6 +5338,150 @@ type property_factory_create {
   from_address: String!
   log_index: Int!
   property: String!
+
+  # An array relationship
+  property_n_allocation(
+    # distinct select on columns
+    distinct_on: [allocator_allocation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [allocator_allocation_result_order_by!]
+
+    # filter the rows returned
+    where: allocator_allocation_result_bool_exp
+  ): [allocator_allocation_result!]!
+
+  # An aggregated array relationship
+  property_n_allocation_aggregate(
+    # distinct select on columns
+    distinct_on: [allocator_allocation_result_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [allocator_allocation_result_order_by!]
+
+    # filter the rows returned
+    where: allocator_allocation_result_bool_exp
+  ): allocator_allocation_result_aggregate!
+
+  # An array relationship
+  property_n_authentication(
+    # distinct select on columns
+    distinct_on: [property_authentication_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [property_authentication_order_by!]
+
+    # filter the rows returned
+    where: property_authentication_bool_exp
+  ): [property_authentication!]!
+
+  # An aggregated array relationship
+  property_n_authentication_aggregate(
+    # distinct select on columns
+    distinct_on: [property_authentication_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [property_authentication_order_by!]
+
+    # filter the rows returned
+    where: property_authentication_bool_exp
+  ): property_authentication_aggregate!
+
+  # An array relationship
+  property_n_authentication_deleted(
+    # distinct select on columns
+    distinct_on: [property_authentication_deleted_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [property_authentication_deleted_order_by!]
+
+    # filter the rows returned
+    where: property_authentication_deleted_bool_exp
+  ): [property_authentication_deleted!]!
+
+  # An aggregated array relationship
+  property_n_authentication_deleted_aggregate(
+    # distinct select on columns
+    distinct_on: [property_authentication_deleted_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [property_authentication_deleted_order_by!]
+
+    # filter the rows returned
+    where: property_authentication_deleted_bool_exp
+  ): property_authentication_deleted_aggregate!
+
+  # An array relationship
+  property_n_lockup(
+    # distinct select on columns
+    distinct_on: [lockup_lockedup_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [lockup_lockedup_order_by!]
+
+    # filter the rows returned
+    where: lockup_lockedup_bool_exp
+  ): [lockup_lockedup!]!
+
+  # An aggregated array relationship
+  property_n_lockup_aggregate(
+    # distinct select on columns
+    distinct_on: [lockup_lockedup_select_column!]
+
+    # limit the number of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [lockup_lockedup_order_by!]
+
+    # filter the rows returned
+    where: lockup_lockedup_bool_exp
+  ): lockup_lockedup_aggregate!
   raw_data: String!
   transaction_index: Int!
 }
@@ -4688,6 +5552,10 @@ input property_factory_create_bool_exp {
   from_address: String_comparison_exp
   log_index: Int_comparison_exp
   property: String_comparison_exp
+  property_n_allocation: allocator_allocation_result_bool_exp
+  property_n_authentication: property_authentication_bool_exp
+  property_n_authentication_deleted: property_authentication_deleted_bool_exp
+  property_n_lockup: lockup_lockedup_bool_exp
   raw_data: String_comparison_exp
   transaction_index: Int_comparison_exp
 }
@@ -4698,7 +5566,7 @@ enum property_factory_create_constraint {
   property_factory_create_pkey
 }
 
-# input type for incrementing integer columne in table "property_factory_create"
+# input type for incrementing integer column in table "property_factory_create"
 input property_factory_create_inc_input {
   block_number: Int
   log_index: Int
@@ -4712,6 +5580,10 @@ input property_factory_create_insert_input {
   from_address: String
   log_index: Int
   property: String
+  property_n_allocation: allocator_allocation_result_arr_rel_insert_input
+  property_n_authentication: property_authentication_arr_rel_insert_input
+  property_n_authentication_deleted: property_authentication_deleted_arr_rel_insert_input
+  property_n_lockup: lockup_lockedup_arr_rel_insert_input
   raw_data: String
   transaction_index: Int
 }
@@ -4789,8 +5661,17 @@ input property_factory_create_order_by {
   from_address: order_by
   log_index: order_by
   property: order_by
+  property_n_allocation_aggregate: allocator_allocation_result_aggregate_order_by
+  property_n_authentication_aggregate: property_authentication_aggregate_order_by
+  property_n_authentication_deleted_aggregate: property_authentication_deleted_aggregate_order_by
+  property_n_lockup_aggregate: lockup_lockedup_aggregate_order_by
   raw_data: order_by
   transaction_index: order_by
+}
+
+# primary key columns input for table: "property_factory_create"
+input property_factory_create_pk_columns_input {
+  event_id: String!
 }
 
 # select columns of table "property_factory_create"
@@ -5463,6 +6344,18 @@ type reward_calculation_result {
   lockup: numeric!
   metrics: String!
   policy: String!
+
+  # An object relationship
+  reward_n_allocation: allocator_allocation_result
+
+  # An object relationship
+  reward_n_authentication: property_authentication
+
+  # An object relationship
+  reward_n_metrics: metrics_factory_create
+
+  # An object relationship
+  reward_n_policy: policy_factory_create
   staking_reward: numeric!
 }
 
@@ -5538,6 +6431,10 @@ input reward_calculation_result_bool_exp {
   lockup: numeric_comparison_exp
   metrics: String_comparison_exp
   policy: String_comparison_exp
+  reward_n_allocation: allocator_allocation_result_bool_exp
+  reward_n_authentication: property_authentication_bool_exp
+  reward_n_metrics: metrics_factory_create_bool_exp
+  reward_n_policy: policy_factory_create_bool_exp
   staking_reward: numeric_comparison_exp
 }
 
@@ -5547,9 +6444,13 @@ enum reward_calculation_result_constraint {
   reward_calculation_result_pkey
 }
 
-# input type for incrementing integer columne in table "reward_calculation_result"
+# input type for incrementing integer column in table "reward_calculation_result"
 input reward_calculation_result_inc_input {
+  allocate_result: numeric
   block_number: Int
+  holder_reward: numeric
+  lockup: numeric
+  staking_reward: numeric
 }
 
 # input type for inserting data into table "reward_calculation_result"
@@ -5561,6 +6462,10 @@ input reward_calculation_result_insert_input {
   lockup: numeric
   metrics: String
   policy: String
+  reward_n_allocation: allocator_allocation_result_obj_rel_insert_input
+  reward_n_authentication: property_authentication_obj_rel_insert_input
+  reward_n_metrics: metrics_factory_create_obj_rel_insert_input
+  reward_n_policy: policy_factory_create_obj_rel_insert_input
   staking_reward: numeric
 }
 
@@ -5643,7 +6548,16 @@ input reward_calculation_result_order_by {
   lockup: order_by
   metrics: order_by
   policy: order_by
+  reward_n_allocation: allocator_allocation_result_order_by
+  reward_n_authentication: property_authentication_order_by
+  reward_n_metrics: metrics_factory_create_order_by
+  reward_n_policy: policy_factory_create_order_by
   staking_reward: order_by
+}
+
+# primary key columns input for table: "reward_calculation_result"
+input reward_calculation_result_pk_columns_input {
+  alocator_allocation_result_event_id: String!
 }
 
 # select columns of table "reward_calculation_result"
@@ -6375,3 +7289,4 @@ type subscription_root {
   # fetch data from the table: "reward_calculation_result" using primary key columns
   reward_calculation_result_by_pk(alocator_allocation_result_event_id: String!): reward_calculation_result
 }
+


### PR DESCRIPTION
## Proposed Changes

I updated the GraphQL API to implements sorting by an external table. With this scheme update, it can now sort the Property list by total reward.

## Implementation

I updated scheme.json and query.