### PR TITLE
Change API endpoint to the production version

### DIFF
--- a/.envrc.tmpl
+++ b/.envrc.tmpl
@@ -1,1 +1,1 @@
-export END_POINT="https://dev-protocol-event-viewer.azurewebsites.net/v1/graphql?code=gzcLW2ZbDLSt6MNQlvd731oAWXznPfeLWH5NU8d8BMYHFemwoIxDLw=="
+export END_POINT="https://api.devprtcl.com/v1/graphql"


### PR DESCRIPTION
## Proposed Changes

We have the GraphQL API endpoint for the production version, now. So I changed the endpoint We're using to that URL.

## Implementation

- Update .envrc.tmpl

---

The production endpoint `https://api.devprtcl.com/v1/graphql` is available now. Please rewrite your `.envrc`.