### PR TITLE
Implemented cache for getting contract address

### DIFF
--- a/packages/web/src/fixtures/dev-kit/client.ts
+++ b/packages/web/src/fixtures/dev-kit/client.ts
@@ -1,6 +1,6 @@
 import { contractFactory } from '@devprtcl/dev-kit-js'
-import { addresses } from '@devprtcl/dev-kit-js'
 import { getAccountAddress } from 'src/fixtures/wallet/utility'
+import { getContractAddress } from './get-contract-address'
 
 const newClient = () => {
   const { ethereum } = window
@@ -13,9 +13,7 @@ const newClient = () => {
 export const getRewardsAmount = async (propertyAddress: string) => {
   const client = newClient()
   if (client) {
-    return client
-      .withdraw(await client.registry(addresses.eth.main.registry).withdraw())
-      .getRewardsAmount(propertyAddress)
+    return client.withdraw(await getContractAddress(client, 'withdraw')).getRewardsAmount(propertyAddress)
   }
   return undefined
 }
@@ -23,7 +21,7 @@ export const getRewardsAmount = async (propertyAddress: string) => {
 export const getTotalStakingAmount = async (proepertyAddress: string) => {
   const client = newClient()
   if (client) {
-    return client.lockup(await client.registry(addresses.eth.main.registry).lockup()).getPropertyValue(proepertyAddress)
+    return client.lockup(await getContractAddress(client, 'lockup')).getPropertyValue(proepertyAddress)
   }
   return undefined
 }
@@ -33,7 +31,7 @@ export const getMyHolderAmount = async (propertyAddress: string) => {
   const accountAddress = await getAccountAddress()
   if (client && accountAddress) {
     return client
-      .withdraw(await client.registry(addresses.eth.main.registry).withdraw())
+      .withdraw(await getContractAddress(client, 'withdraw'))
       .calculateWithdrawableAmount(propertyAddress, accountAddress)
   }
   return undefined
@@ -44,7 +42,7 @@ export const getMyStakingRewardAmount = async (propertyAddress: string) => {
   const accountAddress = await getAccountAddress()
   if (client && accountAddress) {
     return client
-      .lockup(await client.registry(addresses.eth.main.registry).lockup())
+      .lockup(await getContractAddress(client, 'lockup'))
       .calculateWithdrawableInterestAmount(propertyAddress, accountAddress)
   }
   return undefined
@@ -54,9 +52,7 @@ export const getMyStakingAmount = async (propertyAddress: string) => {
   const client = newClient()
   const accountAddress = await getAccountAddress()
   if (client && accountAddress) {
-    return client
-      .lockup(await client.registry(addresses.eth.main.registry).lockup())
-      .getValue(propertyAddress, accountAddress)
+    return client.lockup(await getContractAddress(client, 'lockup')).getValue(propertyAddress, accountAddress)
   }
   return undefined
 }
@@ -64,38 +60,38 @@ export const getMyStakingAmount = async (propertyAddress: string) => {
 export const withdrawHolderAmount = async (propertyAddress: string) => {
   const client = newClient()
   if (!client) throw new Error(`No wallet`)
-  return client.withdraw(await client.registry(addresses.eth.main.registry).withdraw()).withdraw(propertyAddress)
+  return client.withdraw(await getContractAddress(client, 'withdraw')).withdraw(propertyAddress)
 }
 
 export const withdrawStakingAmount = async (propertyAddress: string) => {
   const client = newClient()
   if (!client) throw new Error(`No wallet`)
-  return client.lockup(await client.registry(addresses.eth.main.registry).lockup()).withdraw(propertyAddress)
+  return client.lockup(await getContractAddress(client, 'lockup')).withdraw(propertyAddress)
 }
 
 export const withdrawStakingRewardAmount = async (propertyAddress: string) => {
   const client = newClient()
   if (!client) throw new Error(`No wallet`)
-  return client.lockup(await client.registry(addresses.eth.main.registry).lockup()).withdrawInterest(propertyAddress)
+  return client.lockup(await getContractAddress(client, 'lockup')).withdrawInterest(propertyAddress)
 }
 
 export const stakeDev = async (propertyAddress: string, amount: string) => {
   const client = newClient()
   if (!client) throw new Error(`No wallet`)
-  return client.dev(await client.registry(addresses.eth.main.registry).token()).deposit(propertyAddress, amount)
+  return client.dev(await getContractAddress(client, 'token')).deposit(propertyAddress, amount)
 }
 
 export const cancelStaking = async (propertyAddress: string) => {
   const client = newClient()
   if (!client) throw new Error(`No wallet`)
-  return client.lockup(await client.registry(addresses.eth.main.registry).lockup()).cancel(propertyAddress)
+  return client.lockup(await getContractAddress(client, 'lockup')).cancel(propertyAddress)
 }
 
 export const getLastAssetValueEachMetrics = async (metricsAddress: string) => {
   const client = newClient()
   if (client) {
     return client
-      .allocatorStorage(await client.registry(addresses.eth.main.registry).allocatorStorage())
+      .allocatorStorage(await getContractAddress(client, 'allocatorStorage'))
       .getLastAssetValueEachMetrics(metricsAddress)
   }
   return undefined
@@ -105,7 +101,7 @@ export const getLastAssetValueEachMarketPerBlock = async (marketAddress: string)
   const client = newClient()
   if (client) {
     return client
-      .allocatorStorage(await client.registry(addresses.eth.main.registry).allocatorStorage())
+      .allocatorStorage(await getContractAddress(client, 'allocatorStorage'))
       .getLastAssetValueEachMarketPerBlock(marketAddress)
   }
   return undefined
@@ -114,7 +110,7 @@ export const getLastAssetValueEachMarketPerBlock = async (marketAddress: string)
 export const allocate = async (metricsAddress: string) => {
   const client = newClient()
   if (client) {
-    return client.allocator(await client.registry(addresses.eth.main.registry).allocator()).allocate(metricsAddress)
+    return client.allocator(await getContractAddress(client, 'allocator')).allocate(metricsAddress)
   }
   return undefined
 }
@@ -122,9 +118,7 @@ export const allocate = async (metricsAddress: string) => {
 export const createProperty = async (name: string, symbol: string, author: string) => {
   const client = newClient()
   if (process.env.NODE_ENV == 'production' && client) {
-    return client
-      .propertyFactory(await client.registry(addresses.eth.main.registry).propertyFactory())
-      .create(name, symbol, author)
+    return client.propertyFactory(await getContractAddress(client, 'propertyFactory')).create(name, symbol, author)
   } else if (process.env.NODE_ENV == 'development') {
     console.log('env:', process.env.NODE_ENV, 'return mock value')
     return 'Dummy:0xd5f3c1bA399E000B1a76210d7dB12bb5eefA8e47'
@@ -145,7 +139,7 @@ export const authenticate = async (marketAddress: string, propertyAddress: strin
   if (process.env.NODE_ENV == 'production' && client) {
     const _args = ['', '', '', '', ''].map((x, i) => (args[i] ? args[i] : x))
     return client.market(marketAddress).authenticate(propertyAddress, _args, {
-      metricsFactory: await client.registry(addresses.eth.main.registry).metricsFactory()
+      metricsFactory: await getContractAddress(client, 'metricsFactory')
     })
   } else if (process.env.NODE_ENV == 'development') {
     console.log('env:', process.env.NODE_ENV, 'return mock value')

--- a/packages/web/src/fixtures/dev-kit/get-contract-address.spec.ts
+++ b/packages/web/src/fixtures/dev-kit/get-contract-address.spec.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { DevkitContract } from '@devprtcl/dev-kit-js/esm/client'
+import { getContractAddress } from './get-contract-address'
+import { addresses } from '@devprtcl/dev-kit-js'
+
+describe('get-contract-address.ts', () => {
+  describe('getContractAddress', () => {
+    test('Returns address as a value, and third-argument is "main" by default', async () => {
+      const devkit = {
+        registry: jest.fn().mockImplementation((address: string) => ({
+          lockup: async () => Promise.resolve('LOCKUP_ADDRESS')
+        }))
+      }
+      const result = await getContractAddress((devkit as unknown) as DevkitContract, 'lockup')
+      expect(result).toBe('LOCKUP_ADDRESS')
+      expect(devkit.registry.mock.calls[0][0]).toBe(addresses.eth.main.registry)
+    })
+
+    test('Returns address from the cache when 2nd subsequent call', async () => {
+      const lockup = jest.fn().mockImplementation(async () => Promise.resolve('LOCKUP_ADDRESS'))
+      const devkit = {
+        registry: jest.fn().mockImplementation((address: string) => ({
+          lockup
+        }))
+      }
+      await getContractAddress((devkit as unknown) as DevkitContract, 'lockup', 'CACHE_TEST' as any) // First
+      await getContractAddress((devkit as unknown) as DevkitContract, 'lockup', 'CACHE_TEST' as any) // Second
+      const result = await getContractAddress((devkit as unknown) as DevkitContract, 'lockup', 'CACHE_TEST' as any) // Third
+      expect(result).toBe('LOCKUP_ADDRESS')
+      expect(lockup.mock.calls.length).toBe(1)
+    })
+  })
+})

--- a/packages/web/src/fixtures/dev-kit/get-contract-address.ts
+++ b/packages/web/src/fixtures/dev-kit/get-contract-address.ts
@@ -1,0 +1,22 @@
+import { DevkitContract } from '@devprtcl/dev-kit-js/esm/client'
+import { RegistryContract } from '@devprtcl/dev-kit-js/esm/registry'
+import { addresses } from '@devprtcl/dev-kit-js'
+
+const cache: Map<'main', Map<string, string>> = new Map()
+
+export const getContractAddress = async (
+  client: DevkitContract,
+  contract: keyof RegistryContract,
+  net: 'main' = 'main'
+): Promise<string> =>
+  (async fromCache => {
+    if (typeof fromCache === 'string') {
+      return fromCache
+    }
+    if (!cache.get(net)) {
+      cache.set(net, new Map())
+    }
+    const address = await client.registry(addresses.eth[net]?.registry)[contract]()
+    cache.get(net)?.set(contract, address)
+    return address
+  })(cache.get(net)?.get(contract))


### PR DESCRIPTION
## Proposed Changes

Improve performance by caching got contract address to reduction Web3 requests.

## Implementation

- Added `getContractAddress`
- Use that method in the fixtures/dev-kit/client.ts