### PR TITLE
Add a link to auth page

### DIFF
--- a/packages/web/src/pages/index.tsx
+++ b/packages/web/src/pages/index.tsx
@@ -2,11 +2,9 @@ import React, { useMemo } from 'react'
 import { PropertyCardList } from 'src/components/organisms/PropertyCardList'
 import { MainHeader } from 'src/components/organisms/MainHeader'
 import { Footer } from 'src/components/organisms/Footer'
-import { Button, Modal } from 'antd'
-import { ExclamationCircleOutlined } from '@ant-design/icons'
+import { Button } from 'antd'
 import { useRouter } from 'next/router'
-
-const { confirm } = Modal
+import Link from 'next/link'
 
 type InitialProps = {}
 type Props = {} & InitialProps
@@ -21,35 +19,13 @@ const Index = (_: Props) => {
     return 1
   }, [router])
 
-  const onClick = () => {
-    confirm({
-      title: 'Create a new Property',
-      icon: <ExclamationCircleOutlined />,
-      content: (
-        <>
-          <p>
-            Stakes.social do not yet support the creation of a new Property, but you can create them manually by using
-            Etherscan.
-          </p>
-          <p>Do you want to read a guide blog?</p>
-        </>
-      ),
-      onOk: () => {
-        window.open(
-          'https://medium.com/devprtcl/how-to-register-your-npm-packages-to-dev-protocol-23571c377a12',
-          '_blank'
-        )
-      }
-    })
-  }
-
   return (
     <>
       <MainHeader />
       <div style={{ padding: '1rem', maxWidth: '1048px', marginRight: 'auto', marginLeft: 'auto' }}>
-        <Button onClick={onClick} style={{ display: 'block', margin: '32px 0 32px auto' }}>
-          Create a new Property
-        </Button>
+        <Link href={'/auth'} as={'/auth'}>
+          <Button style={{ display: 'block', margin: '32px 0 32px auto' }}>Create or Configure a Property</Button>
+        </Link>
         <PropertyCardList currentPage={page} />
       </div>
       <Footer />


### PR DESCRIPTION
## Proposed Changes

I added a link to `/auth` page to the "Create a new Property" button.

## Implementation

- Updated Index page
- Rewrite button's label