### PR TITLE
Change default branch name

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -10,7 +10,7 @@
   },
   "command": {
     "version": {
-      "allowBranch": ["master", "release"]
+      "allowBranch": ["main", "release"]
     }
   },
   "npmClient": "yarn",

--- a/packages/web/src/components/molecules/PropertyCoverImage/index.tsx
+++ b/packages/web/src/components/molecules/PropertyCoverImage/index.tsx
@@ -11,7 +11,7 @@ const CoverImage = styled.div`
 `
 
 const assetsAsBackground = (address: string): string =>
-  `url('//raw.githubusercontent.com/dev-protocol/assets/master/property/${address}/header.jpg')`
+  `url('//raw.githubusercontent.com/dev-protocol/assets/main/property/${address}/header.jpg')`
 
 export const PropertyCoverImage = ({ propertyAddress }: Props) => (
   <CoverImage

--- a/packages/web/src/components/organisms/Footer/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/Footer/__snapshots__/index.spec.tsx.snap
@@ -25,7 +25,7 @@ exports[`Footer Snapshot 1`] = `
             , see the 
           </span>
           <a
-            href="//github.com/dev-protocol/protocol/blob/master/docs/WHITEPAPER.md"
+            href="//github.com/dev-protocol/protocol/blob/main/docs/WHITEPAPER.md"
             rel="noreferrer noopener"
             style="text-decoration: underline;"
             target="_blank"

--- a/packages/web/src/components/organisms/Footer/index.tsx
+++ b/packages/web/src/components/organisms/Footer/index.tsx
@@ -23,7 +23,7 @@ export const Footer = () => {
           </a>
           <span>, see the </span>
           <a
-            href="//github.com/dev-protocol/protocol/blob/master/docs/WHITEPAPER.md"
+            href="//github.com/dev-protocol/protocol/blob/main/docs/WHITEPAPER.md"
             target="_blank"
             rel="noreferrer noopener"
             style={{ textDecoration: 'underline' }}

--- a/packages/web/src/fixtures/github/cache-path.ts
+++ b/packages/web/src/fixtures/github/cache-path.ts
@@ -1,4 +1,4 @@
 export const SWRCachePath = {
   getMarketInformation: (marketAddress: string) =>
-    `https://raw.githubusercontent.com/dev-protocol/assets/master/market/${marketAddress}/info.json`
+    `https://raw.githubusercontent.com/dev-protocol/assets/main/market/${marketAddress}/info.json`
 } as const

--- a/packages/web/src/fixtures/github/hooks.ts
+++ b/packages/web/src/fixtures/github/hooks.ts
@@ -14,7 +14,7 @@ export interface MarketInformation {
 }
 
 const getMarketInformation = (marketAddress: string): Promise<MarketInformation> =>
-  fetch(`https://raw.githubusercontent.com/dev-protocol/assets/master/market/${marketAddress}/info.json`).then(res =>
+  fetch(`https://raw.githubusercontent.com/dev-protocol/assets/main/market/${marketAddress}/info.json`).then(res =>
     res.json()
   )
 

--- a/packages/web/src/pages/how-it-works.tsx
+++ b/packages/web/src/pages/how-it-works.tsx
@@ -141,7 +141,7 @@ const HowItWorks = () => {
             <h3>Learn more</h3>
             <div>
               <p>
-                Read the <a href="//github.com/dev-protocol/protocol/blob/master/docs/WHITEPAPER.md">whitepaper</a>.
+                Read the <a href="//github.com/dev-protocol/protocol/blob/main/docs/WHITEPAPER.md">whitepaper</a>.
               </p>
             </div>
           </Section>
@@ -289,7 +289,7 @@ const HowItWorks = () => {
             <p>
               For more information on DEV tokens, please check the <a href="//devprtcl.com">Dev Protocol website</a> and{' '}
               <a
-                href="//github.com/dev-protocol/protocol/blob/master/docs/WHITEPAPER.md"
+                href="//github.com/dev-protocol/protocol/blob/main/docs/WHITEPAPER.md"
                 target="_blank"
                 rel="noreferrer"
               >


### PR DESCRIPTION
## Proposed Changes
It's a fix for the default branch name change in git.

## Implementation
* Fix dependent github URLs in git’s default branch name changes
* Fix the branch name used in `learn.json` (Sorry, I made a mechanical decision based on the branch name, so I don't understand the deeper meaning of it.)