### PR TITLE
Feature profile setting with address name

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ts-jest": "26.1.2",
     "ts-node": "8.10.2",
     "tsconfig-paths": "3.9.0",
-    "typescript": "3.9.6",
+    "typescript": "3.9.7",
     "wait-on": "5.1.0"
   },
   "private": true,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -37,7 +37,7 @@
     "faker": "4.1.0",
     "formik": "2.1.4",
     "formik-material-ui": "2.0.1",
-    "less": "3.12.0",
+    "less": "3.12.2",
     "less-vars-to-js": "1.3.0",
     "next": "9.4.4",
     "next-i18next": "4.5.0",

--- a/packages/web/src/components/molecules/Navigation/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/molecules/Navigation/__snapshots__/index.spec.tsx.snap
@@ -97,6 +97,35 @@ exports[`Navigation Snapshot 1`] = `
       <li
         class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
         role="menuitem"
+        style="display: none;"
+      >
+        <div
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="ant-menu-submenu-title"
+          role="button"
+        >
+          <span>
+            ···
+          </span>
+          <i
+            class="ant-menu-submenu-arrow"
+          />
+        </div>
+      </li>
+      <li
+        class="ant-menu-item ant-menu-item-only-child"
+        role="menuitem"
+      >
+        <a
+          href="/settings/profile"
+        >
+          Account
+        </a>
+      </li>
+      <li
+        class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
+        role="menuitem"
         style="visibility: hidden; position: absolute; display: none;"
       >
         <div

--- a/packages/web/src/components/molecules/Navigation/index.tsx
+++ b/packages/web/src/components/molecules/Navigation/index.tsx
@@ -17,6 +17,11 @@ const navs = [
     key: 'create',
     label: 'Create',
     pathname: '/auth'
+  },
+  {
+    key: 'account',
+    label: 'Account',
+    pathname: '/settings/profile'
   }
 ]
 const NavMenu = styled(Menu)`

--- a/packages/web/src/components/organisms/AuthHeader/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/AuthHeader/__snapshots__/index.spec.tsx.snap
@@ -139,6 +139,35 @@ exports[`AuthHeader Snapshot 1`] = `
         <li
           class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
           role="menuitem"
+          style="display: none;"
+        >
+          <div
+            aria-expanded="false"
+            aria-haspopup="true"
+            class="ant-menu-submenu-title"
+            role="button"
+          >
+            <span>
+              ···
+            </span>
+            <i
+              class="ant-menu-submenu-arrow"
+            />
+          </div>
+        </li>
+        <li
+          class="ant-menu-item ant-menu-item-only-child"
+          role="menuitem"
+        >
+          <a
+            href="/settings/profile"
+          >
+            Account
+          </a>
+        </li>
+        <li
+          class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
+          role="menuitem"
           style="visibility: hidden; position: absolute; display: none;"
         >
           <div

--- a/packages/web/src/components/organisms/Header/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/Header/__snapshots__/index.spec.tsx.snap
@@ -139,6 +139,35 @@ exports[`Header Snapshot 1`] = `
         <li
           class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
           role="menuitem"
+          style="display: none;"
+        >
+          <div
+            aria-expanded="false"
+            aria-haspopup="true"
+            class="ant-menu-submenu-title"
+            role="button"
+          >
+            <span>
+              ···
+            </span>
+            <i
+              class="ant-menu-submenu-arrow"
+            />
+          </div>
+        </li>
+        <li
+          class="ant-menu-item ant-menu-item-only-child"
+          role="menuitem"
+        >
+          <a
+            href="/settings/profile"
+          >
+            Account
+          </a>
+        </li>
+        <li
+          class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
+          role="menuitem"
           style="visibility: hidden; position: absolute; display: none;"
         >
           <div

--- a/packages/web/src/components/organisms/MainHeader/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/MainHeader/__snapshots__/index.spec.tsx.snap
@@ -139,6 +139,35 @@ exports[`MainHeader Snapshot 1`] = `
         <li
           class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
           role="menuitem"
+          style="display: none;"
+        >
+          <div
+            aria-expanded="false"
+            aria-haspopup="true"
+            class="ant-menu-submenu-title"
+            role="button"
+          >
+            <span>
+              ···
+            </span>
+            <i
+              class="ant-menu-submenu-arrow"
+            />
+          </div>
+        </li>
+        <li
+          class="ant-menu-item ant-menu-item-only-child"
+          role="menuitem"
+        >
+          <a
+            href="/settings/profile"
+          >
+            Account
+          </a>
+        </li>
+        <li
+          class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"
+          role="menuitem"
           style="visibility: hidden; position: absolute; display: none;"
         >
           <div

--- a/packages/web/src/components/organisms/UserProfile/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/UserProfile/__snapshots__/index.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`UserProfile Snapshot 1`] = `
 <body>
   <div>
     <div
-      class="sc-AxjAm jdphpg"
+      class="sc-AxjAm jsbXje"
     >
       <section
         class="sc-AxirZ cPzkMd"

--- a/packages/web/src/components/organisms/UserProfile/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/UserProfile/__snapshots__/index.spec.tsx.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UserProfile Snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="sc-AxjAm jdphpg"
+    >
+      <section
+        class="sc-AxirZ cPzkMd"
+      >
+        <div
+          class="sc-AxiKw kJrFcD"
+        >
+          Your Address
+        </div>
+        <div
+          class="sc-AxhCb fOpnxU"
+        >
+          -
+        </div>
+      </section>
+      <section
+        class="sc-AxirZ cPzkMd"
+      >
+        <div
+          class="sc-AxiKw kJrFcD"
+        >
+          Display name
+        </div>
+        <div
+          class="sc-AxhCb fOpnxU"
+        >
+          (Not set)
+        </div>
+      </section>
+      <section
+        class="sc-AxirZ cPzkMd"
+      >
+        <form
+          class="ant-form ant-form-horizontal"
+        >
+          <div
+            class="ant-row"
+          >
+            <div
+              class="ant-col"
+              style="flex: 1 1 252px;"
+            >
+              <div
+                class="ant-row ant-form-item"
+              >
+                <div
+                  class="ant-col ant-col-22 ant-form-item-control"
+                >
+                  <div
+                    class="ant-form-item-control-input"
+                  >
+                    <div
+                      class="ant-form-item-control-input-content"
+                    >
+                      <input
+                        class="ant-input"
+                        id="name"
+                        placeholder="Enter the new display name"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="ant-col"
+              style="flex: 1 1 252px;"
+            >
+              <div
+                class="ant-space ant-space-vertical"
+              >
+                <div
+                  class="ant-space-item"
+                >
+                  <button
+                    class="ant-btn ant-btn-primary"
+                    type="submit"
+                  >
+                    <span>
+                      Sign to Save
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </form>
+      </section>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/web/src/components/organisms/UserProfile/index.spec.tsx
+++ b/packages/web/src/components/organisms/UserProfile/index.spec.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { UserProfile } from '.'
+import 'src/__mocks__/window/matchMedia.mock'
+
+jest.mock('src/fixtures/dev-for-apps/hooks')
+
+describe(`${UserProfile.name}`, () => {
+  test('Snapshot', () => {
+    const component = render(<UserProfile />)
+    const tree = component.baseElement
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/packages/web/src/components/organisms/UserProfile/index.tsx
+++ b/packages/web/src/components/organisms/UserProfile/index.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { Button, Form, Input, Col, Row, Space } from 'antd'
 import { getAccountAddress } from 'src/fixtures/wallet/utility'
 import { useEffectAsync } from 'src/fixtures/utility'
-import { useGetUser } from 'src/fixtures/backend/hooks'
+import { getUser, postUser } from 'src/fixtures/dev-for-apps/utility'
+import { sign } from 'src/fixtures/wallet/utility'
 import styled from 'styled-components'
 
 interface Props {}
@@ -29,14 +30,35 @@ const formLayout = {
   wrapperCol: { span: 22 }
 }
 
-const Contents = ({ address }: { address: string }) => {
-  const { data } = useGetUser(address)
-  const displayName = data?.addressName || '(Not set)'
-  return !data ? (
+export const UserProfile = (_: Props) => {
+  const [author, setAuthor] = useState<string>('')
+  const [isComplete, setIsComplete] = useState<boolean>(true)
+  const [displayName, setDisplayName] = useState<string>('(Not set)')
+  useEffectAsync(async () => {
+    const accountAddress = (await getAccountAddress()) || ''
+    setAuthor(accountAddress)
+    if (accountAddress !== '') {
+      const data = await getUser(accountAddress)
+      setDisplayName(data.displayName)
+    }
+  }, [])
+  const handleSubmitDisplayName = useCallback(
+    async (name: string) => {
+      setIsComplete(false)
+      const message = `submit display name: ${name}`
+      const signature = (await sign(message)) || ''
+      const data = await postUser(name, message, signature, author)
+      setDisplayName(data?.displayName)
+      setIsComplete(true)
+    },
+    [author]
+  )
+
+  return (
     <Container>
       <Section>
         <Title>Your Address</Title>
-        <Text>{address}</Text>
+        <Text>{author}</Text>
       </Section>
 
       <Section>
@@ -45,37 +67,23 @@ const Contents = ({ address }: { address: string }) => {
       </Section>
 
       <Section>
-        <Form {...formLayout}>
+        <Form {...formLayout} onFinish={({ name }) => handleSubmitDisplayName(name)}>
           <Row>
             <Col flex="1 1 252px">
-              <Form.Item name="name" rules={[{ required: true, message: 'Enter the new display name' }]}>
+              <Form.Item name="name" rules={[{ required: true, message: 'Please input display name.' }]}>
                 <Input placeholder="Enter the new display name" />
               </Form.Item>
             </Col>
             <Col flex="1 1 252px">
               <Space direction="vertical" size="small">
-                <Button type="primary">Sign to Save</Button>
+                <Button type="primary" htmlType="submit" loading={!isComplete} disabled={!isComplete}>
+                  Sign to Save
+                </Button>
               </Space>
             </Col>
           </Row>
         </Form>
       </Section>
     </Container>
-  ) : (
-    <></>
-  )
-}
-
-export const UserProfile = (_: Props) => {
-  const [author, setAuthor] = useState<string>('')
-  useEffectAsync(async () => {
-    const accountAddress = await getAccountAddress()
-    const defaultValue = process.env.NODE_ENV === 'development' ? '0x69Cc2C86aeB26f52F6645a2DFdec1051DD5584C0' : ''
-    setAuthor(accountAddress || defaultValue)
-  }, [])
-  return (
-    <div>
-      <Contents address={author} />
-    </div>
   )
 }

--- a/packages/web/src/components/organisms/UserProfile/index.tsx
+++ b/packages/web/src/components/organisms/UserProfile/index.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react'
+import { Button, Form, Input, Col, Row, Space } from 'antd'
+import { getAccountAddress } from 'src/fixtures/wallet/utility'
+import { useEffectAsync } from 'src/fixtures/utility'
+import { useGetUser } from 'src/fixtures/backend/hooks'
+import styled from 'styled-components'
+
+interface Props {}
+
+const Container = styled.div`
+  display: grid;
+  padding: 1rem;
+  max-width: 1120px;
+  margin: auto;
+  grid-gap: 1rem;
+`
+const Section = styled.section`
+  display: grid;
+  padding: 1rem;
+  grid-gap: 0.5rem;
+`
+const Title = styled.div`
+  font-size: 1rem;
+`
+const Text = styled.div`
+  font-size: 2rem;
+`
+const formLayout = {
+  wrapperCol: { span: 22 }
+}
+
+const Contents = ({ address }: { address: string }) => {
+  const { data } = useGetUser(address)
+  const displayName = data?.addressName || '(Not set)'
+  return !data ? (
+    <Container>
+      <Section>
+        <Title>Your Address</Title>
+        <Text>{address}</Text>
+      </Section>
+
+      <Section>
+        <Title>Display name</Title>
+        <Text>{displayName}</Text>
+      </Section>
+
+      <Section>
+        <Form {...formLayout}>
+          <Row>
+            <Col flex="1 1 252px">
+              <Form.Item name="name" rules={[{ required: true, message: 'Enter the new display name' }]}>
+                <Input placeholder="Enter the new display name" />
+              </Form.Item>
+            </Col>
+            <Col flex="1 1 252px">
+              <Space direction="vertical" size="small">
+                <Button type="primary">Sign to Save</Button>
+              </Space>
+            </Col>
+          </Row>
+        </Form>
+      </Section>
+    </Container>
+  ) : (
+    <></>
+  )
+}
+
+export const UserProfile = (_: Props) => {
+  const [author, setAuthor] = useState<string>('')
+  useEffectAsync(async () => {
+    const accountAddress = await getAccountAddress()
+    const defaultValue = process.env.NODE_ENV === 'development' ? '0x69Cc2C86aeB26f52F6645a2DFdec1051DD5584C0' : ''
+    setAuthor(accountAddress || defaultValue)
+  }, [])
+  return (
+    <div>
+      <Contents address={author} />
+    </div>
+  )
+}

--- a/packages/web/src/components/organisms/UserProfile/index.tsx
+++ b/packages/web/src/components/organisms/UserProfile/index.tsx
@@ -4,17 +4,11 @@ import { getAccountAddress } from 'src/fixtures/wallet/utility'
 import { useEffectAsync } from 'src/fixtures/utility'
 import { useGetUser, usePostUser } from 'src/fixtures/dev-for-apps/hooks'
 import { sign } from 'src/fixtures/wallet/utility'
+import { Container } from 'src/components/atoms/Container'
 import styled from 'styled-components'
 
 interface Props {}
 
-const Container = styled.div`
-  display: grid;
-  padding: 1rem;
-  max-width: 1120px;
-  margin: auto;
-  grid-gap: 1rem;
-`
 const Section = styled.section`
   display: grid;
   padding: 1rem;

--- a/packages/web/src/fixtures/dev-for-apps/__mocks__/hooks.ts
+++ b/packages/web/src/fixtures/dev-for-apps/__mocks__/hooks.ts
@@ -1,0 +1,13 @@
+export const useGetUser = () => {
+  return {
+    displayName: 'Get Your Display Name'
+  }
+}
+
+export const usePostUser = () => {
+  return {
+    usePostUser: async () => {
+      return { displayName: 'Post Your Display Name' }
+    }
+  }
+}

--- a/packages/web/src/fixtures/dev-for-apps/cache-path.ts
+++ b/packages/web/src/fixtures/dev-for-apps/cache-path.ts
@@ -1,0 +1,6 @@
+export const BaseUrl = 'https://dev-for-apps.azurewebsites.net/v1/for-apps'
+
+export const SWRCachePath = {
+  getUser: (walletAddress: string) => `get ${BaseUrl}/mainnet/user/${walletAddress}`,
+  postUser: (name: string, signature: string, walletAddress: string) => `post ${BaseUrl}/mainnet/user/${walletAddress}`
+} as const

--- a/packages/web/src/fixtures/dev-for-apps/cache-path.ts
+++ b/packages/web/src/fixtures/dev-for-apps/cache-path.ts
@@ -1,6 +1,5 @@
 export const BaseUrl = 'https://dev-for-apps.azurewebsites.net/v1/for-apps'
 
 export const SWRCachePath = {
-  getUser: (walletAddress: string) => `get ${BaseUrl}/mainnet/user/${walletAddress}`,
-  postUser: (name: string, signature: string, walletAddress: string) => `post ${BaseUrl}/mainnet/user/${walletAddress}`
+  getUser: (walletAddress: string) => `${BaseUrl}/mainnet/user/${walletAddress}`
 } as const

--- a/packages/web/src/fixtures/dev-for-apps/hooks.spec.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.spec.ts
@@ -16,6 +16,16 @@ describe('dev-for-apps hooks', () => {
       const { result } = renderHook(() => useGetUser('0x01234567890'))
       expect(result.current.data).toBe(data)
     })
+
+    test('failure get profile', async () => {
+      const data = undefined
+      const errorMessage = 'error'
+      const error = new Error(errorMessage)
+      ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error }))
+      const { result } = renderHook(() => useGetUser('0x01234567890'))
+      expect(result.current.error).toBe(error)
+      expect(result.current.error?.message).toBe(errorMessage)
+    })
   })
 
   describe('usePostUser', () => {
@@ -30,6 +40,21 @@ describe('dev-for-apps hooks', () => {
       })
       await waitForNextUpdate()
       expect(result.current.error).toBe(undefined)
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    test('failure post profile', async () => {
+      const error = new Error('error')
+      const name = 'name'
+      const signature = 'signature'
+      const signMessage = 'message'
+      const { result, waitForNextUpdate } = renderHook(() => usePostUser())
+      ;(postUser as jest.Mock).mockRejectedValue(error)
+      act(() => {
+        result.current.postUserHandler(name, signature, signMessage, '0x01234567890')
+      })
+      await waitForNextUpdate()
+      expect(result.current.error).toBe(error)
       expect(result.current.isLoading).toBe(false)
     })
   })

--- a/packages/web/src/fixtures/dev-for-apps/hooks.spec.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.spec.ts
@@ -1,0 +1,36 @@
+import useSWR from 'swr'
+import { renderHook, act } from '@testing-library/react-hooks'
+import { useGetUser, usePostUser } from './hooks'
+import { postUser } from './utility'
+
+jest.mock('swr')
+jest.mock('src/fixtures/utility')
+jest.mock('src/fixtures/dev-for-apps/utility.ts')
+
+describe('dev-for-apps hooks', () => {
+  describe('useGetUser', () => {
+    test('success get profile', async () => {
+      const data = { displayName: 'Get Your Dispaly Name' }
+      const error = undefined
+      ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error }))
+      const { result } = renderHook(() => useGetUser('0x01234567890'))
+      expect(result.current.data).toBe(data)
+    })
+  })
+
+  describe('usePostUser', () => {
+    test('success post profile', async () => {
+      const name = 'name'
+      const signature = 'signature'
+      const signMessage = 'message'
+      const { result, waitForNextUpdate } = renderHook(() => usePostUser())
+      ;(postUser as jest.Mock).mockResolvedValue({ displayName: 'name' })
+      act(() => {
+        result.current.postUserHandler(name, signature, signMessage, '0x01234567890')
+      })
+      await waitForNextUpdate()
+      expect(result.current.error).toBe(undefined)
+      expect(result.current.isLoading).toBe(false)
+    })
+  })
+})

--- a/packages/web/src/fixtures/dev-for-apps/hooks.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.ts
@@ -34,7 +34,7 @@ export const usePostUser = () => {
           setError(err)
           message.error({ content: err.message, key })
           setIsLoading(false)
-          return {}
+          return { error: err }
         })
     },
     []

--- a/packages/web/src/fixtures/dev-for-apps/hooks.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.ts
@@ -1,0 +1,23 @@
+import { SWRCachePath } from './cache-path'
+import useSWR from 'swr'
+import { message } from 'antd'
+import { UnwrapFunc } from '../utility'
+import { getUser, postUser } from './utility'
+
+export const useGetUser = (walletAddress: string) => {
+  const { data, error } = useSWR<UnwrapFunc<typeof getUser>, Error>(
+    SWRCachePath.getUser(walletAddress),
+    () => getUser(walletAddress),
+    { onError: err => message.error(err.message) }
+  )
+  return { data, error }
+}
+
+export const usePostUser = (name: string, signMessage: string, signature: string, walletAddress: string) => {
+  const { data, error } = useSWR<UnwrapFunc<typeof postUser>, Error>(
+    SWRCachePath.postUser(name, signature, walletAddress),
+    () => postUser(name, signMessage, signature, walletAddress),
+    { onError: err => message.error(err.message) }
+  )
+  return { data, error }
+}

--- a/packages/web/src/fixtures/dev-for-apps/hooks.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.ts
@@ -22,9 +22,11 @@ export const usePostUser = () => {
   const postUserHandler = useCallback(
     async (name: string, signMessage: string, signature: string, walletAddress: string) => {
       setIsLoading(true)
+      message.loading({ content: 'update display name...', duration: 0, key })
       setError(undefined)
       return postUser(name, signMessage, signature, walletAddress)
         .then(result => {
+          message.success({ content: 'success update display name', key })
           setIsLoading(false)
           return result
         })

--- a/packages/web/src/fixtures/dev-for-apps/hooks.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.ts
@@ -1,3 +1,4 @@
+import { useState, useCallback } from 'react'
 import { SWRCachePath } from './cache-path'
 import useSWR from 'swr'
 import { message } from 'antd'
@@ -5,19 +6,37 @@ import { UnwrapFunc } from '../utility'
 import { getUser, postUser } from './utility'
 
 export const useGetUser = (walletAddress: string) => {
+  const shouldFetch = walletAddress !== ''
   const { data, error } = useSWR<UnwrapFunc<typeof getUser>, Error>(
-    SWRCachePath.getUser(walletAddress),
+    shouldFetch ? SWRCachePath.getUser(walletAddress) : null,
     () => getUser(walletAddress),
     { onError: err => message.error(err.message) }
   )
   return { data, error }
 }
 
-export const usePostUser = (name: string, signMessage: string, signature: string, walletAddress: string) => {
-  const { data, error } = useSWR<UnwrapFunc<typeof postUser>, Error>(
-    SWRCachePath.postUser(name, signature, walletAddress),
-    () => postUser(name, signMessage, signature, walletAddress),
-    { onError: err => message.error(err.message) }
+export const usePostUser = () => {
+  const key = 'useGetUser'
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [error, setError] = useState<Error>()
+  const postUserHandler = useCallback(
+    async (name: string, signMessage: string, signature: string, walletAddress: string) => {
+      setIsLoading(true)
+      setError(undefined)
+      return postUser(name, signMessage, signature, walletAddress)
+        .then(result => {
+          setIsLoading(false)
+          return result
+        })
+        .catch(err => {
+          setError(err)
+          message.error({ content: err.message, key })
+          setIsLoading(false)
+          return {}
+        })
+    },
+    []
   )
-  return { data, error }
+
+  return { postUserHandler, isLoading, error }
 }

--- a/packages/web/src/fixtures/dev-for-apps/utility.ts
+++ b/packages/web/src/fixtures/dev-for-apps/utility.ts
@@ -1,0 +1,30 @@
+import { BaseUrl } from './cache-path'
+
+export interface UserInformation {
+  displayName: string
+}
+
+export const getUser = (walletAddress: string): Promise<UserInformation> =>
+  fetch(`${BaseUrl}/mainnet/user/${walletAddress}`, {
+    mode: 'cors'
+  })
+    .then(res => res.json())
+    .catch(() => '')
+
+export const postUser = (
+  name: string,
+  signMessage: string,
+  signature: string,
+  walletAddress: string
+): Promise<UserInformation> =>
+  fetch(`${BaseUrl}/mainnet/user/${walletAddress}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8'
+    },
+    body: JSON.stringify({
+      signature: signature,
+      displayName: name,
+      message: signMessage
+    })
+  }).then(res => res.json())

--- a/packages/web/src/fixtures/dev-for-apps/utility.ts
+++ b/packages/web/src/fixtures/dev-for-apps/utility.ts
@@ -5,9 +5,7 @@ export interface UserInformation {
 }
 
 export const getUser = (walletAddress: string): Promise<UserInformation> =>
-  fetch(`${BaseUrl}/mainnet/user/${walletAddress}`, {
-    mode: 'cors'
-  })
+  fetch(`${BaseUrl}/mainnet/user/${walletAddress}`)
     .then(res => res.json())
     .catch(() => '')
 

--- a/packages/web/src/fixtures/wallet/utility.ts
+++ b/packages/web/src/fixtures/wallet/utility.ts
@@ -56,3 +56,16 @@ export const getBlockNumber = async () => {
   }
   return undefined
 }
+
+export const sign = async (message: string) => {
+  const { ethereum } = window
+  if (ethereum) {
+    const address = await getAccountAddress()
+    if (address === undefined) {
+      return undefined
+    }
+    const signature = await new Web3(ethereum).eth.personal.sign(message, address, '')
+    return signature
+  }
+  return undefined
+}

--- a/packages/web/src/pages/settings/profile.tsx
+++ b/packages/web/src/pages/settings/profile.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Footer } from 'src/components/organisms/Footer'
+import { Header } from 'src/components/organisms/Header'
+import { Headline } from 'src/components/atoms/Headline'
+import { H2 } from 'src/components/atoms/Typography'
+import { UserProfile } from 'src/components/organisms/UserProfile'
+
+type Props = {}
+
+const SettingsProfile = (_: Props) => {
+  return (
+    <>
+      <Header />
+      <Headline height={100}>
+        <H2>Profile Settings</H2>
+      </Headline>
+      <UserProfile />
+      <Footer />
+    </>
+  )
+}
+
+export default SettingsProfile

--- a/yarn.lock
+++ b/yarn.lock
@@ -10293,10 +10293,10 @@ less-vars-to-js@1.3.0:
   dependencies:
     strip-json-comments "^2.0.1"
 
-less@3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/less/-/less-3.12.0.tgz#f23f9bd94ba72495994865d84e3b5ac6ee8a0363"
-  integrity sha512-3mmSHFRP9hGxxQgAKgChfau1LO3ksV/zyZf1qd2ENyBV778NA9Ids99wFRA20jE+5prT7oScKod8PoGlxSe1gg==
+less@3.12.2:
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/less/-/less-3.12.2.tgz#157e6dd32a68869df8859314ad38e70211af3ab4"
+  integrity sha512-+1V2PCMFkL+OIj2/HrtrvZw0BC0sYLMICJfbQjuj/K8CEnlrFX6R5cKKgzzttsZDHyxQNL1jqMREjKN3ja/E3Q==
   dependencies:
     tslib "^1.10.0"
   optionalDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -15982,10 +15982,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.9.6:
-  version "3.9.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
-  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 ua-parser-js@^0.7.18, ua-parser-js@^0.7.20:
   version "0.7.21"


### PR DESCRIPTION
## Proposed Changes
add Profile Settings page.
By adding this page, will be able to name the wallet address.

![profilesettings](https://user-images.githubusercontent.com/150309/88122559-e0ff0900-cc03-11ea-848a-8a66ff80d4d3.png)

## Implementation
* Add
  * `pages/settings/profile` and `components/organisms/UserProfile`
  * fixtures for [dev-for-apps](https://github.com/dev-protocol/dev-for-apps)
    * If the wallet address is not empty, fetch (GET or POST) the data
  * wrapper of `Web3.eth.personal.sign()` in `packages/web/src/fixtures/wallet/utility.ts`

## TODO
* [x] add unit test
* [x] refactoring