### PR TITLE
Feature simple search properties

### DIFF
--- a/packages/graphql/src/queries/listPropertyCreateFactory.graphql
+++ b/packages/graphql/src/queries/listPropertyCreateFactory.graphql
@@ -1,14 +1,18 @@
-query ListProperty($limit: Int, $offset: Int) {
+query ListProperty($limit: Int, $offset: Int, $ilike: String) {
   property_factory_create(limit: $limit, offset: $offset, order_by: {
-    allocation_aggregate: {
-      sum: {
-        result: desc_nulls_last
+      allocation_aggregate: {
+        sum: {
+          result: desc_nulls_last
+        }
       }
-    }
-  }) {
+    },
+    where: { authentication: { authentication_id: { _ilike: $ilike } } }
+  ) {
     ...propertyFactoryCreate
   }
-  property_factory_create_aggregate {
+  property_factory_create_aggregate(
+    where: { authentication: { authentication_id: { _ilike: $ilike } } }
+  ) {
     aggregate {
       count
     }

--- a/packages/graphql/src/react-apollo/generated.tsx
+++ b/packages/graphql/src/react-apollo/generated.tsx
@@ -6266,6 +6266,7 @@ export type ListAllocatorAllocationResultsQuery = { __typename?: 'query_root' } 
 export type ListPropertyQueryVariables = Exact<{
   limit?: Maybe<Scalars['Int']>
   offset?: Maybe<Scalars['Int']>
+  ilike?: Maybe<Scalars['String']>
 }>
 
 export type ListPropertyQuery = { __typename?: 'query_root' } & {
@@ -6618,15 +6619,16 @@ export type ListAllocatorAllocationResultsQueryResult = ApolloReactCommon.QueryR
   ListAllocatorAllocationResultsQueryVariables
 >
 export const ListPropertyDocument = gql`
-  query ListProperty($limit: Int, $offset: Int) {
+  query ListProperty($limit: Int, $offset: Int, $ilike: String) {
     property_factory_create(
       limit: $limit
       offset: $offset
       order_by: { allocation_aggregate: { sum: { result: desc_nulls_last } } }
+      where: { authentication: { authentication_id: { _ilike: $ilike } } }
     ) {
       ...propertyFactoryCreate
     }
-    property_factory_create_aggregate {
+    property_factory_create_aggregate(where: { authentication: { authentication_id: { _ilike: $ilike } } }) {
       aggregate {
         count
       }
@@ -6649,6 +6651,7 @@ export const ListPropertyDocument = gql`
  *   variables: {
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
+ *      ilike: // value for 'ilike'
  *   },
  * });
  */

--- a/packages/web/src/components/organisms/PropertyCardList/PropertySearchForm.tsx
+++ b/packages/web/src/components/organisms/PropertyCardList/PropertySearchForm.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Col, Row, Form, Input } from 'antd'
+
+interface Props {
+  onSubmitSearchProperty: (word: string) => void
+}
+
+const formLayout = {
+  wrapperCol: { span: 18 }
+}
+
+export const PropertySearchForm = ({ onSubmitSearchProperty }: Props) => {
+  return (
+    <>
+      <Form {...formLayout}>
+        <Row>
+          <Col sm={20} md={12}>
+            <Form.Item name="searchWord">
+              <Input.Search
+                placeholder="input property search word"
+                onSearch={searchWord => onSubmitSearchProperty(searchWord)}
+                enterButton
+              />
+            </Form.Item>
+          </Col>
+        </Row>
+      </Form>
+    </>
+  )
+}

--- a/packages/web/src/components/organisms/PropertyCardList/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/PropertyCardList/__snapshots__/index.spec.tsx.snap
@@ -5,6 +5,82 @@ exports[`PropertyCardList Snapshot 1`] = `
   <div>
     <div>
       <div
+        style="margin: 20px 0px 0px 0px;"
+      >
+        <form
+          class="ant-form ant-form-horizontal"
+        >
+          <div
+            class="ant-row"
+          >
+            <div
+              class="ant-col ant-col-sm-20 ant-col-md-12"
+            >
+              <div
+                class="ant-row ant-form-item"
+              >
+                <div
+                  class="ant-col ant-col-18 ant-form-item-control"
+                >
+                  <div
+                    class="ant-form-item-control-input"
+                  >
+                    <div
+                      class="ant-form-item-control-input-content"
+                    >
+                      <span
+                        class="ant-input-search ant-input-search-enter-button ant-input-group-wrapper"
+                      >
+                        <span
+                          class="ant-input-wrapper ant-input-group"
+                        >
+                          <input
+                            class="ant-input"
+                            id="searchWord"
+                            placeholder="input property search word"
+                            type="text"
+                            value=""
+                          />
+                          <span
+                            class="ant-input-group-addon"
+                          >
+                            <button
+                              class="ant-btn ant-input-search-button ant-btn-primary"
+                              type="button"
+                            >
+                              <span
+                                aria-label="search"
+                                class="anticon anticon-search"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class=""
+                                  data-icon="search"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height="1em"
+                                  viewBox="64 64 896 896"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+                                  />
+                                </svg>
+                              </span>
+                            </button>
+                          </span>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+      <div
         style="margin: 54px 0px;"
       >
         <div

--- a/packages/web/src/components/organisms/PropertyCardList/index.tsx
+++ b/packages/web/src/components/organisms/PropertyCardList/index.tsx
@@ -2,23 +2,41 @@ import React, { useCallback, useState } from 'react'
 import { Spin, Pagination } from 'antd'
 import { useListPropertyQuery } from '@dev/graphql'
 import { PropertyCard } from './PropertyCard'
+import { PropertySearchForm } from './PropertySearchForm'
 import { useRouter } from 'next/router'
 
 interface Props {
   currentPage: number
+  searchWord: string
 }
 
 const DEFAULT_PER_PAGE = 10
 
-export const PropertyCardList = ({ currentPage }: Props) => {
+export const PropertyCardList = ({ currentPage, searchWord }: Props) => {
   const [perPage, setPerPage] = useState(DEFAULT_PER_PAGE)
-  const { data, loading } = useListPropertyQuery({ variables: { limit: perPage, offset: (currentPage - 1) * perPage } })
+  const { data, loading } = useListPropertyQuery({
+    variables: {
+      limit: perPage,
+      offset: (currentPage - 1) * perPage,
+      ilike: searchWord !== '' ? `%${searchWord}%` : undefined
+    }
+  })
   const router = useRouter()
-  const handlePagination = useCallback((page: number) => router.push({ pathname: '/', query: { page } }), [router])
+  const handlePagination = useCallback(
+    (page: number) => {
+      const query = searchWord !== '' ? { page, word: searchWord } : { page }
+      router.push({ pathname: '/', query })
+    },
+    [router, searchWord]
+  )
   const handleShowSizeChange = (_: number, pageSize: number) => setPerPage(pageSize)
+  const handleSearch = useCallback((word: string) => router.push({ pathname: '/', query: { word } }), [router])
 
   return (
     <div>
+      <div style={{ margin: '20px 0 0 0' }}>
+        <PropertySearchForm onSubmitSearchProperty={handleSearch} />
+      </div>
       {loading && <Spin size="large" style={{ display: 'block', width: 'auto', padding: '100px' }} />}
       {data && (
         <>

--- a/packages/web/src/pages/index.tsx
+++ b/packages/web/src/pages/index.tsx
@@ -21,6 +21,13 @@ const Index = (_: Props) => {
     }
     return 1
   }, [router])
+  const word = useMemo(() => {
+    const { word: wordStr } = router.query
+    if (typeof wordStr === 'string') {
+      return wordStr
+    }
+    return ''
+  }, [router])
 
   return (
     <>
@@ -28,7 +35,7 @@ const Index = (_: Props) => {
       <MainHeader />
       <div style={{ padding: '1rem', maxWidth: '1048px', marginRight: 'auto', marginLeft: 'auto' }}>
         <SupplySummaly apy={apy} creators={creators} annualSupplyGrowthRatio={annualSupplyGrowthRatio}></SupplySummaly>
-        <PropertyCardList currentPage={page} />
+        <PropertyCardList currentPage={page} searchWord={word} />
       </div>
       <Footer />
     </>


### PR DESCRIPTION
## Proposed Changes
Motivation: I'd like to search for the target properties

![search-properties](https://user-images.githubusercontent.com/150309/88754848-bd573800-d19a-11ea-8d33-633726011403.png)

## Implementation
* partial match by search word
* access with `/?word=xx`