### PR TITLE
Fix breaks layout

### DIFF
--- a/packages/web/.babelrc
+++ b/packages/web/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["next/babel"],
   "plugins": [
+    ["styled-components", { "displayName": false }],
     [
       "import",
       {

--- a/packages/web/src/components/atoms/HelpUs/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/atoms/HelpUs/__snapshots__/index.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`HelpUs Snapshot HelpUs 1`] = `
 <body>
   <div>
     <a
-      class="ant-btn sc-AxjAm dlzIWn ant-btn-circle ant-btn-lg ant-btn-icon-only"
+      class="ant-btn sc-1q9xl64-0 huclnC ant-btn-circle ant-btn-lg ant-btn-icon-only"
       href="//paper.dropbox.com/doc/Were-missing-the-following-resources--A1eBXtT1lNDsorUT3g4zQYk7AQ-QU7SbfwRE7V6TnCTyGWQM"
       target="_blank"
     >

--- a/packages/web/src/components/atoms/Typography/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/atoms/Typography/__snapshots__/index.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`Title Snapshot Body1 1`] = `
 <body>
   <div>
     <span
-      class="ant-typography sc-AxjAm tCIrM"
+      class="ant-typography gjzh4b-0 gkjPEK"
     >
       body1
     </span>

--- a/packages/web/src/components/molecules/CancelForm/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/molecules/CancelForm/__snapshots__/index.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`CancelForm Snapshot 1`] = `
 <body>
   <div>
     <div
-      class="sc-AxjAm StDqN"
+      class="dy1yq4-0 dLtIEa"
     >
       <p>
         Cancel Staking

--- a/packages/web/src/components/molecules/ConnectedApps/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/molecules/ConnectedApps/__snapshots__/index.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`ConnectedApps Snapshot 1`] = `
         Connected Apps
       </p>
       <div
-        class="ant-empty sc-AxjAm bHhTWA"
+        class="ant-empty sc-14abpdu-0 fJdiGV"
       >
         <div
           class="ant-empty-image"

--- a/packages/web/src/components/molecules/Navigation/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/molecules/Navigation/__snapshots__/index.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`Navigation Snapshot 1`] = `
 <body>
   <div>
     <ul
-      class="ant-menu sc-AxjAm jAJNAM ant-menu-light ant-menu-root ant-menu-horizontal"
+      class="ant-menu sc-9o0t4s-0 buSwZn ant-menu-light ant-menu-root ant-menu-horizontal"
       role="menu"
     >
       <li

--- a/packages/web/src/components/molecules/PropertyCoverImage/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/molecules/PropertyCoverImage/__snapshots__/index.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`PropertyCoverImage Snapshot 1`] = `
 <body>
   <div>
     <div
-      class="sc-AxjAm gvnZMS"
+      class="z7fmw0-0 hayUlK"
       style="background-size: cover;"
     />
   </div>

--- a/packages/web/src/components/molecules/SupplySummaly/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/molecules/SupplySummaly/__snapshots__/index.spec.tsx.snap
@@ -4,24 +4,24 @@ exports[`SupplySummaly Snapshot 1`] = `
 <body>
   <div>
     <div
-      class="sc-AxjAm StDqN"
+      class="re975l-0 bfHDoa"
     >
       <div
-        class="sc-AxirZ ekmHZP"
+        class="re975l-1 ieMmDO"
       >
         <span>
           APY for Stakers:
         </span>
         <span
-          class="sc-AxiKw eUIEFs"
+          class="re975l-2 kELOqq"
         >
           <span
-            class="sc-AxhCb eXfxQM"
+            class="re975l-3 kJEXkv"
           >
             1
           </span>
           <span
-            class="sc-AxhUy fSZkcE"
+            class="re975l-4 cHCObH"
           >
             0
             %
@@ -29,33 +29,33 @@ exports[`SupplySummaly Snapshot 1`] = `
         </span>
       </div>
       <div
-        class="sc-AxirZ ekmHZP"
+        class="re975l-1 ieMmDO"
       >
         <span>
           APY for Creators:
         </span>
         <span
-          class="sc-AxiKw eUIEFs"
+          class="re975l-2 kELOqq"
         >
           -
         </span>
       </div>
       <div
-        class="sc-AxirZ ekmHZP"
+        class="re975l-1 ieMmDO"
       >
         <span>
           Annual Supply Growth:
         </span>
         <span
-          class="sc-AxiKw eUIEFs"
+          class="re975l-2 kELOqq"
         >
           <span
-            class="sc-AxhCb eXfxQM"
+            class="re975l-3 kJEXkv"
           >
             1
           </span>
           <span
-            class="sc-AxhUy fSZkcE"
+            class="re975l-4 cHCObH"
           >
             0
             %

--- a/packages/web/src/components/molecules/WithdrawCard/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/molecules/WithdrawCard/__snapshots__/index.spec.tsx.snap
@@ -17,14 +17,14 @@ exports[`WithdrawCard Snapshot 1`] = `
             style="flex: 1 1 252px;"
           >
             <span
-              class="sc-AxjAm fxjwKc"
+              class="xpbyv8-0 dTqzPw"
             >
               Withdraw 
               Holder
                Reward
             </span>
             <div
-              class="sc-AxirZ dRlJLK"
+              class="xpbyv8-1 gxLEuM"
             >
               1000
                DEV

--- a/packages/web/src/components/molecules/WithdrawForm/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/molecules/WithdrawForm/__snapshots__/index.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`WithdrawForm Snapshot 1`] = `
 <body>
   <div>
     <div
-      class="sc-AxjAm StDqN"
+      class="sc-1xz1jp7-0 jyGBzw"
     >
       <p>
         Withdraw 
@@ -12,10 +12,10 @@ exports[`WithdrawForm Snapshot 1`] = `
          Reward
       </p>
       <div
-        class="sc-AxirZ djXUlT"
+        class="sc-1xz1jp7-1 eWFbMA"
       >
         <div
-          class="sc-AxiKw dDKlW"
+          class="sc-1xz1jp7-2 cBVrPw"
         >
           1000
            DEV

--- a/packages/web/src/components/organisms/AssetOutline/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/AssetOutline/__snapshots__/index.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`AssetOutline Snapshot 1`] = `
 <body>
   <div>
     <div
-      class="sc-AxirZ sc-AxiKw jJlZOn"
+      class="sc-10zn2q0-0 sc-10zn2q0-1 bmuHvT"
     >
       <div>
         <p>
@@ -24,7 +24,7 @@ exports[`AssetOutline Snapshot 1`] = `
                 class="ant-list-items"
               >
                 <li
-                  class="ant-list-item sc-AxgMl cQBOeR"
+                  class="ant-list-item sc-10zn2q0-4 kqGDRV"
                 >
                   <span
                     style="overflow: auto;"
@@ -51,14 +51,14 @@ exports[`AssetOutline Snapshot 1`] = `
           Staking Ratio
         </p>
         <div
-          class="sc-AxirZ sc-AxhCb dzDAau"
+          class="sc-10zn2q0-0 sc-10zn2q0-2 hrcNTJ"
         >
           <div
-            class="sc-AxjAm kkhYpD"
+            class="sc-5ahzw8-0 bIgDqy"
           />
           <div>
             <span
-              class="sc-AxhUy dQrdLI"
+              class="sc-10zn2q0-3 dHeguj"
             >
               26
               %

--- a/packages/web/src/components/organisms/AuthForm/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/AuthForm/__snapshots__/index.spec.tsx.snap
@@ -4,10 +4,10 @@ exports[`AuthForm Snapshot 1`] = `
 <body>
   <div>
     <div
-      class="sc-AxjAm cRjsHd"
+      class="bja7zw-0 bVsGvT"
     >
       <div
-        class="sc-AxirZ iaKHBx"
+        class="bja7zw-1 cmaEXV"
       >
         <span>
           Associating Property:
@@ -17,7 +17,7 @@ exports[`AuthForm Snapshot 1`] = `
         </span>
       </div>
       <div
-        class="sc-AxirZ iaKHBx"
+        class="bja7zw-1 cmaEXV"
       >
         <span>
           Arguments:

--- a/packages/web/src/components/organisms/AuthHeader/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/AuthHeader/__snapshots__/index.spec.tsx.snap
@@ -4,16 +4,16 @@ exports[`AuthHeader Snapshot 1`] = `
 <body>
   <div>
     <header
-      class="sc-AxiKw cUSjnZ"
+      class="sc-1bz6snd-0 beiBaa"
     >
       <header
-        class="sc-AxhCb gYeOme"
+        class="sc-1bz6snd-1 bTHlXA"
       >
         <div
-          class="sc-AxhUy TlMSf"
+          class="sc-1bz6snd-2 ioLeod"
         >
           <a
-            class="sc-AxjAm bqVefi"
+            class="sc-38x7tx-0 kobKfO"
             href="/"
           >
             <svg
@@ -46,7 +46,7 @@ exports[`AuthHeader Snapshot 1`] = `
         </div>
       </header>
       <ul
-        class="ant-menu sc-AxirZ kAUAIX ant-menu-light ant-menu-root ant-menu-horizontal"
+        class="ant-menu sc-9o0t4s-0 buSwZn ant-menu-light ant-menu-root ant-menu-horizontal"
         role="menu"
       >
         <li
@@ -158,7 +158,7 @@ exports[`AuthHeader Snapshot 1`] = `
       </ul>
     </header>
     <div
-      class="sc-AxgMl idyFvI"
+      class="sc-9gd508-0 bIxJUr"
       height="300"
     >
       <h2

--- a/packages/web/src/components/organisms/CancelStaking/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/CancelStaking/__snapshots__/index.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`CancelStaking Snapshot 1`] = `
 <body>
   <div>
     <div
-      class="sc-AxjAm StDqN"
+      class="dy1yq4-0 dLtIEa"
     >
       <p>
         Cancel Staking

--- a/packages/web/src/components/organisms/Footer/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/Footer/__snapshots__/index.spec.tsx.snap
@@ -4,10 +4,10 @@ exports[`Footer Snapshot 1`] = `
 <body>
   <div>
     <footer
-      class="sc-AxirZ coIxHU"
+      class="sc-1fvy930-0 gDJCtJ"
     >
       <div
-        class="sc-AxjAm jsbXje"
+        class="sc-1wzqvkc-0 fMjlez"
       >
         <p>
           <span>
@@ -105,7 +105,7 @@ exports[`Footer Snapshot 1`] = `
         </p>
       </div>
       <div
-        class="sc-AxjAm jsbXje"
+        class="sc-1wzqvkc-0 fMjlez"
       >
         <svg
           viewBox="0 0 408 146"
@@ -155,7 +155,7 @@ exports[`Footer Snapshot 1`] = `
         </svg>
       </div>
       <div
-        class="sc-AxjAm jsbXje"
+        class="sc-1wzqvkc-0 fMjlez"
       >
         <small>
           All emojis designed by 

--- a/packages/web/src/components/organisms/Header/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/Header/__snapshots__/index.spec.tsx.snap
@@ -4,16 +4,16 @@ exports[`Header Snapshot 1`] = `
 <body>
   <div>
     <header
-      class="sc-AxiKw cUSjnZ"
+      class="sc-1bz6snd-0 beiBaa"
     >
       <header
-        class="sc-AxhCb gYeOme"
+        class="sc-1bz6snd-1 bTHlXA"
       >
         <div
-          class="sc-AxhUy TlMSf"
+          class="sc-1bz6snd-2 ioLeod"
         >
           <a
-            class="sc-AxjAm bqVefi"
+            class="sc-38x7tx-0 kobKfO"
             href="/"
           >
             <svg
@@ -46,7 +46,7 @@ exports[`Header Snapshot 1`] = `
         </div>
       </header>
       <ul
-        class="ant-menu sc-AxirZ kAUAIX ant-menu-light ant-menu-root ant-menu-horizontal"
+        class="ant-menu sc-9o0t4s-0 buSwZn ant-menu-light ant-menu-root ant-menu-horizontal"
         role="menu"
       >
         <li

--- a/packages/web/src/components/organisms/MainHeader/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/MainHeader/__snapshots__/index.spec.tsx.snap
@@ -4,16 +4,16 @@ exports[`MainHeader Snapshot 1`] = `
 <body>
   <div>
     <header
-      class="sc-AxiKw cUSjnZ"
+      class="sc-1bz6snd-0 beiBaa"
     >
       <header
-        class="sc-AxhCb gYeOme"
+        class="sc-1bz6snd-1 bTHlXA"
       >
         <div
-          class="sc-AxhUy TlMSf"
+          class="sc-1bz6snd-2 ioLeod"
         >
           <a
-            class="sc-AxjAm bqVefi"
+            class="sc-38x7tx-0 kobKfO"
             href="/"
           >
             <svg
@@ -46,7 +46,7 @@ exports[`MainHeader Snapshot 1`] = `
         </div>
       </header>
       <ul
-        class="ant-menu sc-AxirZ kAUAIX ant-menu-light ant-menu-root ant-menu-horizontal"
+        class="ant-menu sc-9o0t4s-0 buSwZn ant-menu-light ant-menu-root ant-menu-horizontal"
         role="menu"
       >
         <li
@@ -158,7 +158,7 @@ exports[`MainHeader Snapshot 1`] = `
       </ul>
     </header>
     <div
-      class="sc-AxgMl fIIWAw"
+      class="sc-9gd508-0 gmFvJL"
     >
       <h1
         class="ant-typography"
@@ -167,7 +167,7 @@ exports[`MainHeader Snapshot 1`] = `
         Make a community sustainable together
       </h1>
       <a
-        class="sc-AxjAm bqVefi"
+        class="sc-38x7tx-0 kobKfO"
         href="/how-it-works"
       >
         <button

--- a/packages/web/src/components/organisms/PoliciyList/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/PoliciyList/__snapshots__/index.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`PoliciesList Snapshot 1`] = `
 <body>
   <div>
     <div
-      class="sc-AxirZ eUnHfC"
+      class="sc-1xckrk7-0 gZVfpu"
     >
       <div
         style="margin: 0px auto; align-items: center;"

--- a/packages/web/src/components/organisms/PossessionOutline/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/PossessionOutline/__snapshots__/index.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`PossessionOutline Snapshot 1`] = `
 <body>
   <div>
     <div
-      class="sc-AxjAm wHYuT"
+      class="zlzook-0 bcZdPH"
     >
       <div
         class="ant-statistic"

--- a/packages/web/src/components/organisms/PropertyCardList/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/PropertyCardList/__snapshots__/index.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`PropertyCardList Snapshot 1`] = `
         style="margin: 54px 0px;"
       >
         <div
-          class="sc-AxirZ ggxpbf"
+          class="k29mxm-0 bFDgzV"
         >
           <div
             class="ant-row"
@@ -17,7 +17,7 @@ exports[`PropertyCardList Snapshot 1`] = `
               class="ant-col ant-col-sm-24 ant-col-md-10"
             >
               <div
-                class="ant-statistic sc-AxgMl VTTce"
+                class="ant-statistic k29mxm-4 chEuZd"
               >
                 <div
                   class="ant-statistic-title"
@@ -36,10 +36,10 @@ exports[`PropertyCardList Snapshot 1`] = `
               </div>
             </div>
             <div
-              class="ant-col sc-AxhCb cihgDy ant-col-sm-24 ant-col-md-14"
+              class="ant-col k29mxm-2 kyfkZA ant-col-sm-24 ant-col-md-14"
             >
               <div
-                class="ant-row sc-AxiKw fdRmGt"
+                class="ant-row k29mxm-1 EIlQ"
               >
                 <div
                   class="ant-col ant-col-12"
@@ -112,14 +112,14 @@ exports[`PropertyCardList Snapshot 1`] = `
                 >
                   <div>
                     <span
-                      class="sc-AxhUy cHgPVK"
+                      class="k29mxm-3 bUjBJG"
                       style="position: absolute;"
                     >
                       25
                       % of the total stakes
                     </span>
                     <div
-                      class="sc-AxjAm kkhYpD"
+                      class="sc-5ahzw8-0 bIgDqy"
                     />
                   </div>
                 </div>

--- a/packages/web/src/components/organisms/PropertyHeader/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/PropertyHeader/__snapshots__/index.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`PropertyHeader Snapshot 1`] = `
 <body>
   <div>
     <div
-      class="sc-AxjAm czRilP"
+      class="sc-1bnntxi-0 jCsCmb"
     >
       <span
         class="heading"

--- a/packages/web/src/components/organisms/PropertySelectForm/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/PropertySelectForm/__snapshots__/index.spec.tsx.snap
@@ -4,10 +4,10 @@ exports[`PropertySelectForm Snapshot 1`] = `
 <body>
   <div>
     <div
-      class="sc-AxgMl eURUGM"
+      class="sc-5tv67d-0 gsMsuS"
     >
       <div
-        class="sc-AxheI sc-Axmtr jubTaX"
+        class="sc-5tv67d-1 sc-5tv67d-2 beBfOo"
       >
         <span>
           Associating Property:
@@ -73,10 +73,10 @@ exports[`PropertySelectForm Snapshot 1`] = `
         </div>
       </div>
       <div
-        class="sc-AxheI hoCgHb"
+        class="sc-5tv67d-1 fpxiQK"
       >
         <button
-          class="ant-btn sc-AxmLO daLPAh ant-btn-link"
+          class="ant-btn sc-5tv67d-3 jEUHCK ant-btn-link"
           type="button"
         >
           <span>

--- a/packages/web/src/components/organisms/StakeForm/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/StakeForm/__snapshots__/index.spec.tsx.snap
@@ -8,13 +8,13 @@ exports[`StakeForm Snapshot 1`] = `
         Stake Now
       </p>
       <span
-        class="ant-input-search sc-AxjAm izUpZQ ant-input-search-enter-button ant-input-search-large ant-input-group-wrapper ant-input-group-wrapper-lg"
+        class="ant-input-search w1tfby-0 chlMkK ant-input-search-enter-button ant-input-search-large ant-input-group-wrapper ant-input-group-wrapper-lg"
       >
         <span
           class="ant-input-wrapper ant-input-group"
         >
           <span
-            class="ant-input-search sc-AxjAm izUpZQ ant-input-search-enter-button ant-input-search-large ant-input-affix-wrapper ant-input-affix-wrapper-lg"
+            class="ant-input-search w1tfby-0 chlMkK ant-input-search-enter-button ant-input-search-large ant-input-affix-wrapper ant-input-affix-wrapper-lg"
           >
             <input
               class="ant-input ant-input-lg"

--- a/packages/web/src/components/organisms/TransactionForm/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/TransactionForm/__snapshots__/index.spec.tsx.snap
@@ -4,10 +4,10 @@ exports[`TransactionForm Snapshot 1`] = `
 <body>
   <div>
     <div
-      class="sc-AxhCb inaksa"
+      class="sc-1e3xeyk-0 ebcfrJ"
     >
       <div
-        class="sc-AxjAm StDqN"
+        class="sc-1xz1jp7-0 jyGBzw"
       >
         <p>
           Withdraw 
@@ -15,10 +15,10 @@ exports[`TransactionForm Snapshot 1`] = `
            Reward
         </p>
         <div
-          class="sc-AxirZ djXUlT"
+          class="sc-1xz1jp7-1 eWFbMA"
         >
           <div
-            class="sc-AxiKw dDKlW"
+            class="sc-1xz1jp7-2 cBVrPw"
           >
             5000
              DEV
@@ -34,7 +34,7 @@ exports[`TransactionForm Snapshot 1`] = `
         </div>
       </div>
       <div
-        class="sc-AxjAm StDqN"
+        class="sc-1xz1jp7-0 jyGBzw"
       >
         <p>
           Withdraw 
@@ -42,10 +42,10 @@ exports[`TransactionForm Snapshot 1`] = `
            Reward
         </p>
         <div
-          class="sc-AxirZ djXUlT"
+          class="sc-1xz1jp7-1 eWFbMA"
         >
           <div
-            class="sc-AxiKw dDKlW"
+            class="sc-1xz1jp7-2 cBVrPw"
           >
             6000
              DEV


### PR DESCRIPTION
## Proposed Changes
related issue: #335 

The layout is broken in the rare case where `styled-components` are used.

I've reproduced it in my local environment.
The procedure was to keep multiple tabs or windows open in the browser, and the phenomenon occurred on one of the tabs that was accessed at the same time.
(The probability of this happening is about 2/5 times.)

I checked the HTML when the problem occurred in the developer tool and it looks like this:
![reproduce-problem](https://user-images.githubusercontent.com/150309/88993507-249ef480-d321-11ea-88a0-f8e4b84e6fa7.png)

`div.sc-fzoyAV.fQsatj` and `span.sc-fzoLag.BNtsP`, which should have been separate, were duplicated.

After making this change, the event no longer recurs.
![add-setting-to-babelrc](https://user-images.githubusercontent.com/150309/88993681-8fe8c680-d321-11ea-9292-32671e8f61bb.png)

As mentioned above, this is due to a change in the ID numbering rules, so it is possible that the problem may still occur.
However, this setting itself exists in the nextjs example, so we think it's best to add the setting.
https://github.com/vercel/next.js/blob/f9b98e6cf7868a1254d8767057dd5665b312f66a/examples/with-styled-components/.babelrc#L3

## Implementation
* add styled-components plugin in .babelrc (69027bdedd8b22740a1d6cd34d3f472bfa6a1e0c)
* all changes other than the above are updates to the unit test snapshot
