### PR TITLE
Feature: Top stakers of a property

### DIFF
--- a/packages/graphql/src/react-apollo/generated.tsx
+++ b/packages/graphql/src/react-apollo/generated.tsx
@@ -2,7 +2,7 @@ import gql from 'graphql-tag'
 import * as ApolloReactCommon from '@apollo/react-common'
 import * as ApolloReactHooks from '@apollo/react-hooks'
 export type Maybe<T> = T
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] }
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string

--- a/packages/web/public/locales/en/Common.json
+++ b/packages/web/public/locales/en/Common.json
@@ -1,0 +1,1 @@
+{ "totalRewards": "Total Reward" }

--- a/packages/web/public/locales/ja/Common.json
+++ b/packages/web/public/locales/ja/Common.json
@@ -1,0 +1,1 @@
+{ "totalRewards": "総報酬" }

--- a/packages/web/src/components/organisms/TopStakers/index.tsx
+++ b/packages/web/src/components/organisms/TopStakers/index.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+import { useQuery } from 'react-apollo'
+import getTopStakersOfPropertyQuery from './query/getTopStakersOfProperty'
+import styled from 'styled-components'
+
+interface TopStakersProps {
+  propertyAdress: string
+}
+
+const ListItem = styled.div`
+  display: grid;
+  justify-content: center;
+  align-items: center;
+  grid-template-columns: 1fr 4fr 1fr;
+`
+
+const StakersList = styled.ol`
+  list-style: none;
+  padding: 12px 0 0 0 !important;
+
+  li {
+    color: black;
+    border-bottom: 1px solid lightgrey;
+    padding: 12px 18px;
+
+    &:last-child {
+      border-bottom: 0;
+    }
+  }
+`
+
+const PlaceHolderList = styled.div`
+  display: flex;
+  min-height: 400px;
+  justify-content: center;
+  align-items: center;
+`
+
+const Flex = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+const TopStakers = ({ propertyAdress }: TopStakersProps) => {
+  const { data: topStakersData, loading } = useQuery(getTopStakersOfPropertyQuery, {
+    variables: {
+      limit: 5,
+      property_address: propertyAdress
+    }
+  })
+
+  const stakerItems: Array<{ account_address: string; value: number }> = topStakersData?.property_lockup
+
+  return (
+    <Flex>
+      <h2>Top stakers</h2>
+      {loading && (
+        <PlaceHolderList>
+          <div>loading...</div>
+        </PlaceHolderList>
+      )}
+
+      {!loading && !topStakersData && (
+        <PlaceHolderList>
+          <div>No data available...</div>
+        </PlaceHolderList>
+      )}
+
+      <StakersList>
+        {stakerItems?.map(({ account_address, value }, index) => (
+          <li key={`${account_address}-${value}`}>
+            <ListItem>
+              <div>{index + 1}</div>
+              <Flex>
+                <h3>Account address</h3>
+                <span> {`${account_address}`}</span>
+              </Flex>
+              <Flex>
+                <h3>Value</h3>
+                <span>{`${(value / Math.pow(10, 18)).toFixed(2)}`}</span>
+              </Flex>
+            </ListItem>
+          </li>
+        ))}
+      </StakersList>
+    </Flex>
+  )
+}
+
+export default TopStakers

--- a/packages/web/src/components/organisms/TopStakers/index.tsx
+++ b/packages/web/src/components/organisms/TopStakers/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useQuery } from 'react-apollo'
 import getTopStakersOfPropertyQuery from './query/getTopStakersOfProperty'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 interface TopStakersProps {
   propertyAdress: string
@@ -29,11 +29,13 @@ const StakersList = styled.ol`
   }
 `
 
-const PlaceHolderList = styled.div`
-  display: flex;
-  min-height: 400px;
-  justify-content: center;
-  align-items: center;
+const PlaceHolderList = styled.div<{ noData?: boolean }>`
+  ${({ noData }) => css`
+    display: flex;
+    min-height: ${noData ? '150px' : '400px'};
+    justify-content: center;
+    align-items: center;
+  `}
 `
 
 const Flex = styled.div`
@@ -60,8 +62,8 @@ const TopStakers = ({ propertyAdress }: TopStakersProps) => {
         </PlaceHolderList>
       )}
 
-      {!loading && !topStakersData && (
-        <PlaceHolderList>
+      {!loading && stakerItems.length === 0 && (
+        <PlaceHolderList noData>
           <div>No data available...</div>
         </PlaceHolderList>
       )}

--- a/packages/web/src/components/organisms/TopStakers/query/getTopStakersOfProperty.tsx
+++ b/packages/web/src/components/organisms/TopStakers/query/getTopStakersOfProperty.tsx
@@ -1,0 +1,12 @@
+import gql from 'graphql-tag'
+
+export const getTopStakersOfPropertyQuery = gql`
+  query getTopStakersOfProperty($property_address: String!, $limit: Int!) {
+    property_lockup(where: { property_address: { _eq: $property_address } }, order_by: { value: desc }, limit: $limit) {
+      account_address
+      value
+    }
+  }
+`
+
+export default getTopStakersOfPropertyQuery

--- a/packages/web/src/pages/[propertyAddress].tsx
+++ b/packages/web/src/pages/[propertyAddress].tsx
@@ -14,6 +14,7 @@ import { Header } from 'src/components/organisms/Header'
 import { StakeForm } from 'src/components/organisms/StakeForm'
 import { CancelStaking } from 'src/components/organisms/CancelStaking'
 import { ConnectedApps } from 'src/components/molecules/ConnectedApps'
+import TopStakers from 'src/components/organisms/TopStakers'
 
 type Props = {}
 
@@ -22,6 +23,7 @@ const Main = styled(Container)`
   grid-gap: 1rem;
   grid-template-areas:
     'cover'
+    'topstake'
     'stake'
     'outline'
     'possession'
@@ -33,6 +35,7 @@ const Main = styled(Container)`
     grid-template-columns: 0.9fr auto;
     grid-template-areas:
       'cover outline'
+      'topstake outline'
       'stake outline'
       'possession outline'
       'transact outline'
@@ -46,6 +49,11 @@ const Cover = styled.div`
 const Outline = styled(AssetOutline)`
   grid-area: outline;
 `
+
+const TopStakerList = styled(TopStakers)`
+  grid-area: topstake;
+`
+
 const Stake = styled(StakeForm)`
   grid-area: stake;
 `
@@ -79,6 +87,7 @@ const PropertyAddressDetail = (_: Props) => {
             <a target="_blank">Change the cover image</a>
           </Link>
         </Cover>
+        <TopStakerList propertyAdress={propertyAddress} />
         <Stake propertyAddress={propertyAddress} />
         <Outline propertyAddress={propertyAddress} />
         <Possession propertyAddress={propertyAddress} />


### PR DESCRIPTION
## Proposed Changes
A top stakers section should be added to every detail page to provide greater insights into a property
## Implementation
I added a new TopStakers component to the overview which fetches the top 5 stakers and displays these in a list

![image](https://user-images.githubusercontent.com/5823083/89397775-8d66e200-d710-11ea-9227-93552805a062.png)
