### PR TITLE
support to auth GitHub market assets with Khaos

### DIFF
--- a/packages/web/src/components/organisms/AuthForm/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/AuthForm/__snapshots__/index.spec.tsx.snap
@@ -61,38 +61,37 @@ exports[`AuthForm Snapshot 1`] = `
                 <div
                   class="ant-form-item-control-input-content"
                 >
-                  <p>
-                    <input
-                      class="ant-input"
-                      placeholder="Personal Access Token"
-                      type="text"
-                      value=""
-                    />
-                  </p>
-                  <p>
-                    Please
-                     
-                    <a
-                      href="https://github.com/settings/tokens/new"
-                      rel="noreferrer"
-                      target="_blank"
-                    >
-                      create a Personal Access Token 
-                      <span
-                        class="ant-typography"
-                      >
-                        <mark>
-                          without all scopes
-                        </mark>
-                      </span>
-                    </a>
-                     
-                    and paste it here.
-                  </p>
+                  <input
+                    class="ant-input"
+                    id="basic_personalAccessToken"
+                    placeholder="Personal Access Token"
+                    type="text"
+                    value=""
+                  />
                 </div>
               </div>
             </div>
           </div>
+          <p>
+            Please
+             
+            <a
+              href="https://github.com/settings/tokens/new"
+              rel="noreferrer"
+              target="_blank"
+            >
+              create a Personal Access Token 
+              <span
+                class="ant-typography"
+              >
+                <mark>
+                  without all scopes
+                </mark>
+              </span>
+            </a>
+             
+            and paste it here.
+          </p>
           <button
             class="ant-btn ant-btn-primary"
             type="submit"

--- a/packages/web/src/components/organisms/AuthForm/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/AuthForm/__snapshots__/index.spec.tsx.snap
@@ -37,7 +37,7 @@ exports[`AuthForm Snapshot 1`] = `
         <div
           class="ant-result-title"
         >
-          GitHub Market is currently by invitation only
+          GitHub Market is currently invite-only
         </div>
         <div
           class="ant-result-extra"

--- a/packages/web/src/components/organisms/AuthForm/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/AuthForm/__snapshots__/index.spec.tsx.snap
@@ -7,6 +7,58 @@ exports[`AuthForm Snapshot 1`] = `
       class="bja7zw-0 bVsGvT"
     >
       <div
+        class="ant-result ant-result-info"
+        style="margin-bottom: 6rem; padding: 0px;"
+      >
+        <div
+          class="ant-result-icon"
+        >
+          <span
+            aria-label="exclamation-circle"
+            class="anticon anticon-exclamation-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="exclamation-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-result-title"
+        >
+          GitHub Market is currently by invitation only
+        </div>
+        <div
+          class="ant-result-extra"
+        >
+          <p>
+            Please send our team an invitation request via the form.
+          </p>
+          <p>
+            <a
+              class="ant-btn ant-btn-primary"
+              href="https://forms.gle/MVxEvdPNNig9YdBu6"
+              target="_blank"
+            >
+              <span>
+                Apply form
+              </span>
+            </a>
+          </p>
+        </div>
+      </div>
+      <div
         class="bja7zw-1 cmaEXV"
       >
         <span>

--- a/packages/web/src/components/organisms/AuthForm/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/AuthForm/__snapshots__/index.spec.tsx.snap
@@ -61,13 +61,34 @@ exports[`AuthForm Snapshot 1`] = `
                 <div
                   class="ant-form-item-control-input-content"
                 >
-                  <input
-                    class="ant-input"
-                    id="basic_publicAccessToken"
-                    placeholder="public access token"
-                    type="text"
-                    value=""
-                  />
+                  <p>
+                    <input
+                      class="ant-input"
+                      placeholder="Personal Access Token"
+                      type="text"
+                      value=""
+                    />
+                  </p>
+                  <p>
+                    Please
+                     
+                    <a
+                      href="https://github.com/settings/tokens/new"
+                      rel="noreferrer"
+                      target="_blank"
+                    >
+                      create a Personal Access Token 
+                      <span
+                        class="ant-typography"
+                      >
+                        <mark>
+                          without all scopes
+                        </mark>
+                      </span>
+                    </a>
+                     
+                    and paste it here.
+                  </p>
                 </div>
               </div>
             </div>

--- a/packages/web/src/components/organisms/AuthForm/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/AuthForm/__snapshots__/index.spec.tsx.snap
@@ -26,6 +26,52 @@ exports[`AuthForm Snapshot 1`] = `
           class="ant-form ant-form-horizontal"
           id="basic"
         >
+          <div
+            class="ant-row ant-form-item"
+          >
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <input
+                    class="ant-input"
+                    id="basic_repositoryName"
+                    placeholder="repository name"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-row ant-form-item"
+          >
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <input
+                    class="ant-input"
+                    id="basic_publicAccessToken"
+                    placeholder="public access token"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
           <button
             class="ant-btn ant-btn-primary"
             type="submit"

--- a/packages/web/src/components/organisms/AuthForm/index.tsx
+++ b/packages/web/src/components/organisms/AuthForm/index.tsx
@@ -70,7 +70,7 @@ const GitHubMarketSchemeInput = () => {
 
 const Notify = () => (
   <Result
-    title="GitHub Market is currently by invitation only"
+    title="GitHub Market is currently invite-only"
     style={{ marginBottom: '6rem', padding: 0 }}
     extra={
       <>

--- a/packages/web/src/components/organisms/AuthForm/index.tsx
+++ b/packages/web/src/components/organisms/AuthForm/index.tsx
@@ -4,6 +4,7 @@ import { useMarketScheme, useAuthenticate } from 'src/fixtures/dev-kit/hooks'
 import { usePostSignGitHubMarketAsset } from 'src/fixtures/khaos/hooks'
 import { useEffectAsync } from 'src/fixtures/utility'
 import styled from 'styled-components'
+import Text from 'antd/lib/typography/Text'
 
 const NpmMarketContractAddress = '0x88c7B1f41DdE50efFc25541a2E0769B887eB2ee7'
 
@@ -44,7 +45,7 @@ const GitHubMarketSchemeInput = () => {
     <>
       <Form.Item
         name="repositoryName"
-        rules={[{ required: true, message: 'Please input GitHub Repository name.' }]}
+        rules={[{ required: true, message: 'Please input GitHub Repository name (e.g., your/awesome-repos)' }]}
         key="repositoryName"
       >
         <Input placeholder="repository name" />
@@ -54,7 +55,16 @@ const GitHubMarketSchemeInput = () => {
         rules={[{ required: true, message: 'Please input PAT.' }]}
         key="publicAccessToken"
       >
-        <Input placeholder="public access token" />
+        <p>
+          <Input placeholder="Personal Access Token" />
+        </p>
+        <p>
+          Please{' '}
+          <a href="https://github.com/settings/tokens/new" target="_blank" rel="noreferrer">
+            create a Personal Access Token <Text mark>without all scopes</Text>
+          </a>{' '}
+          and paste it here.
+        </p>
       </Form.Item>
     </>
   )

--- a/packages/web/src/components/organisms/AuthForm/index.tsx
+++ b/packages/web/src/components/organisms/AuthForm/index.tsx
@@ -51,21 +51,19 @@ const GitHubMarketSchemeInput = () => {
         <Input placeholder="repository name" />
       </Form.Item>
       <Form.Item
-        name="publicAccessToken"
+        name="personalAccessToken"
         rules={[{ required: true, message: 'Please input PAT.' }]}
-        key="publicAccessToken"
+        key="personalAccessToken"
       >
-        <p>
-          <Input placeholder="Personal Access Token" />
-        </p>
-        <p>
-          Please{' '}
-          <a href="https://github.com/settings/tokens/new" target="_blank" rel="noreferrer">
-            create a Personal Access Token <Text mark>without all scopes</Text>
-          </a>{' '}
-          and paste it here.
-        </p>
+        <Input placeholder="Personal Access Token" />
       </Form.Item>
+      <p>
+        Please{' '}
+        <a href="https://github.com/settings/tokens/new" target="_blank" rel="noreferrer">
+          create a Personal Access Token <Text mark>without all scopes</Text>
+        </a>{' '}
+        and paste it here.
+      </p>
     </>
   )
 }
@@ -82,8 +80,8 @@ export const AuthForm = ({ market, property }: Props) => {
         ? Object.values(values)
         : await (async () => {
             const repository: string = values.repositoryName
-            const publicAccessToken = values.publicAccessToken
-            await postSignGitHubMarketAssetHandler(repository, publicAccessToken)
+            const personalAccessToken = values.personalAccessToken
+            await postSignGitHubMarketAssetHandler(repository, personalAccessToken)
             return [repository, khaosSigned?.publicSignature || '']
           })()
 

--- a/packages/web/src/components/organisms/AuthForm/index.tsx
+++ b/packages/web/src/components/organisms/AuthForm/index.tsx
@@ -67,14 +67,14 @@ export const AuthForm = ({ market, property }: Props) => {
   const { data: khaosSigned, postSignGitHubMarketAssetHandler } = usePostSignGitHubMarketAsset()
   const { authenticate } = useAuthenticate()
   const onFinish = async (values: any) => {
-    const authRequestData =
+    const authRequestData: string[] =
       market === NpmMarketContractAddress
         ? Object.values(values)
-        : (async () => {
-            const repository = values.repositoryName
+        : await (async () => {
+            const repository: string = values.repositoryName
             const publicAccessToken = values.publicAccessToken
             await postSignGitHubMarketAssetHandler(repository, publicAccessToken)
-            return [repository, khaosSigned?.publicSignature]
+            return [repository, khaosSigned?.publicSignature || '']
           })()
 
     const metrics = await authenticate(market, property, authRequestData)

--- a/packages/web/src/components/organisms/AuthForm/index.tsx
+++ b/packages/web/src/components/organisms/AuthForm/index.tsx
@@ -68,6 +68,23 @@ const GitHubMarketSchemeInput = () => {
   )
 }
 
+const Notify = () => (
+  <Result
+    title="GitHub Market is currently by invitation only"
+    style={{ marginBottom: '6rem', padding: 0 }}
+    extra={
+      <>
+        <p>Please send our team an invitation request via the form.</p>
+        <p>
+          <Button type="primary" href="https://forms.gle/MVxEvdPNNig9YdBu6" target="_blank">
+            Apply form
+          </Button>
+        </p>
+      </>
+    }
+  />
+)
+
 export const AuthForm = ({ market, property }: Props) => {
   const [schemeList, setSchemeList] = useState<string[]>([])
   const [metrics, setMetrics] = useState<string>('')
@@ -99,6 +116,7 @@ export const AuthForm = ({ market, property }: Props) => {
 
   return (
     <Container>
+      {market !== NpmMarketContractAddress && metrics === '' ? <Notify /> : ''}
       <Row>
         <span>Associating Property:</span>
         <span>{property}</span>

--- a/packages/web/src/components/organisms/AuthForm/index.tsx
+++ b/packages/web/src/components/organisms/AuthForm/index.tsx
@@ -72,7 +72,7 @@ export const AuthForm = ({ market, property }: Props) => {
   const [schemeList, setSchemeList] = useState<string[]>([])
   const [metrics, setMetrics] = useState<string>('')
   const { marketScheme } = useMarketScheme()
-  const { data: khaosSigned, postSignGitHubMarketAssetHandler } = usePostSignGitHubMarketAsset()
+  const { postSignGitHubMarketAssetHandler } = usePostSignGitHubMarketAsset()
   const { authenticate } = useAuthenticate()
   const onFinish = async (values: any) => {
     const authRequestData: string[] =
@@ -81,8 +81,8 @@ export const AuthForm = ({ market, property }: Props) => {
         : await (async () => {
             const repository: string = values.repositoryName
             const personalAccessToken = values.personalAccessToken
-            await postSignGitHubMarketAssetHandler(repository, personalAccessToken)
-            return [repository, khaosSigned?.publicSignature || '']
+            const khaos = await postSignGitHubMarketAssetHandler(repository, personalAccessToken)
+            return [repository, khaos.publicSignature || '']
           })()
 
     const metrics = await authenticate(market, property, authRequestData)

--- a/packages/web/src/fixtures/khaos/cache-path.ts
+++ b/packages/web/src/fixtures/khaos/cache-path.ts
@@ -1,4 +1,7 @@
-export const BaseUrl = 'https://khaos-eth-mainnet.azurewebsites.net'
+export const BaseUrl =
+  process.env.NODE_ENV === 'production'
+    ? 'https://khaos-eth-mainnet.azurewebsites.net'
+    : 'https://khaos-eth-ropsten.azurewebsites.net'
 
 export const SWRCachePath = {
   postSignGitHubMarketAsset: () => `${BaseUrl}/sign/github-market`

--- a/packages/web/src/fixtures/khaos/cache-path.ts
+++ b/packages/web/src/fixtures/khaos/cache-path.ts
@@ -1,0 +1,5 @@
+export const BaseUrl = 'https://khaos-eth-mainnet.azurewebsites.net'
+
+export const SWRCachePath = {
+  postSignGitHubMarketAsset: () => `${BaseUrl}/sign/github-market`
+} as const

--- a/packages/web/src/fixtures/khaos/hooks.spec.ts
+++ b/packages/web/src/fixtures/khaos/hooks.spec.ts
@@ -27,8 +27,8 @@ describe('khaos hooks', () => {
       const { result, waitForNextUpdate } = renderHook(() => usePostSignGitHubMarketAsset())
       act(() => {
         const repository = 'test/repo'
-        const publicAccessToken = 'dummy pat'
-        result.current.postSignGitHubMarketAssetHandler(repository, publicAccessToken)
+        const personalAccessToken = 'dummy pat'
+        result.current.postSignGitHubMarketAssetHandler(repository, personalAccessToken)
       })
       await waitForNextUpdate()
       expect(result.current.isLoading).toBe(false)

--- a/packages/web/src/fixtures/khaos/hooks.spec.ts
+++ b/packages/web/src/fixtures/khaos/hooks.spec.ts
@@ -1,0 +1,37 @@
+import useSWR from 'swr'
+import { renderHook, act } from '@testing-library/react-hooks'
+import { usePostSignGitHubMarketAsset } from './hooks'
+import { postSignGitHubMarketAsset } from './utility'
+
+jest.mock('swr')
+jest.mock('src/fixtures/utility')
+jest.mock('src/fixtures/khaos/utility.ts')
+
+describe('khaos hooks', () => {
+  describe('usePostSignGitHubMarketAsset', () => {
+    test('success post auth github asset', async () => {
+      const data = { publicSignature: 'dummy signature' }
+      const error = undefined
+      ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error }))
+      ;(postSignGitHubMarketAsset as jest.Mock).mockResolvedValue({ publicSignature: 'dummy signature' })
+      const { result } = renderHook(() => usePostSignGitHubMarketAsset())
+      expect(result.current.data).toBe(data)
+    })
+
+    test('failure post auth github asset', async () => {
+      const data = undefined
+      const errorMessage = 'error'
+      const error = new Error(errorMessage)
+      ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error, mutate: () => {} }))
+      ;(postSignGitHubMarketAsset as jest.Mock).mockResolvedValue({ publicSignature: 'dummy signature' })
+      const { result, waitForNextUpdate } = renderHook(() => usePostSignGitHubMarketAsset())
+      act(() => {
+        const repository = 'test/repo'
+        const publicAccessToken = 'dummy pat'
+        result.current.postSignGitHubMarketAssetHandler(repository, publicAccessToken)
+      })
+      await waitForNextUpdate()
+      expect(result.current.isLoading).toBe(false)
+    })
+  })
+})

--- a/packages/web/src/fixtures/khaos/hooks.ts
+++ b/packages/web/src/fixtures/khaos/hooks.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import useSWR from 'swr'
 import { message } from 'antd'
 import { UnwrapFunc } from '../utility'
@@ -7,6 +8,7 @@ import { sign } from 'src/fixtures/wallet/utility'
 
 export const usePostSignGitHubMarketAsset = () => {
   const key = 'usePostSignGitHubMarketAsset'
+  const [isLoading, setIsLoading] = useState<boolean>(false)
   const { data, mutate } = useSWR<UnwrapFunc<typeof postSignGitHubMarketAsset>, Error>(
     SWRCachePath.postSignGitHubMarketAsset()
   )
@@ -15,21 +17,24 @@ export const usePostSignGitHubMarketAsset = () => {
     const signMessage = repository
     const signature = (await sign(signMessage)) || ''
 
+    setIsLoading(true)
     message.loading({ content: 'authenticate asset', duration: 0, key })
 
     await mutate(
       postSignGitHubMarketAsset(signMessage, signature, publicAccessToken)
         .then(result => {
           message.success({ content: 'success to authenticate asset', key })
+          setIsLoading(false)
           return result
         })
         .catch(err => {
           message.error({ content: err.message, key })
-          return Promise.reject(data)
+          setIsLoading(false)
+          return Promise.reject(err)
         }),
       false
     )
   }
 
-  return { data, postSignGitHubMarketAssetHandler }
+  return { data, postSignGitHubMarketAssetHandler, isLoading }
 }

--- a/packages/web/src/fixtures/khaos/hooks.ts
+++ b/packages/web/src/fixtures/khaos/hooks.ts
@@ -13,7 +13,7 @@ export const usePostSignGitHubMarketAsset = () => {
     SWRCachePath.postSignGitHubMarketAsset()
   )
 
-  const postSignGitHubMarketAssetHandler = async (repository: string, publicAccessToken: string) => {
+  const postSignGitHubMarketAssetHandler = async (repository: string, personalAccessToken: string) => {
     const signMessage = repository
     const signature = (await sign(signMessage)) || ''
 
@@ -21,7 +21,7 @@ export const usePostSignGitHubMarketAsset = () => {
     message.loading({ content: 'authenticate asset', duration: 0, key })
 
     await mutate(
-      postSignGitHubMarketAsset(signMessage, signature, publicAccessToken)
+      postSignGitHubMarketAsset(signMessage, signature, personalAccessToken)
         .then(result => {
           message.success({ content: 'success to authenticate asset', key })
           setIsLoading(false)

--- a/packages/web/src/fixtures/khaos/hooks.ts
+++ b/packages/web/src/fixtures/khaos/hooks.ts
@@ -3,7 +3,7 @@ import useSWR from 'swr'
 import { message } from 'antd'
 import { UnwrapFunc } from '../utility'
 import { SWRCachePath } from './cache-path'
-import { postSignGitHubMarketAsset } from './utility'
+import { postSignGitHubMarketAsset, GitHubAssetInformation } from './utility'
 import { sign } from 'src/fixtures/wallet/utility'
 
 export const usePostSignGitHubMarketAsset = () => {
@@ -26,9 +26,14 @@ export const usePostSignGitHubMarketAsset = () => {
     await mutate(
       postSignGitHubMarketAsset(signMessage, signature || '', personalAccessToken)
         .then(result => {
-          message.success({ content: 'success to authenticate asset', key })
           setIsLoading(false)
-          return result
+          if (result instanceof Error) {
+            message.error({ content: result.message, key })
+            return {} as GitHubAssetInformation
+          } else {
+            message.success({ content: 'success to authenticate asset', key })
+            return result
+          }
         })
         .catch(err => {
           message.error({ content: err.message, key })

--- a/packages/web/src/fixtures/khaos/hooks.ts
+++ b/packages/web/src/fixtures/khaos/hooks.ts
@@ -9,9 +9,7 @@ import { sign } from 'src/fixtures/wallet/utility'
 export const usePostSignGitHubMarketAsset = () => {
   const key = 'usePostSignGitHubMarketAsset'
   const [isLoading, setIsLoading] = useState<boolean>(false)
-  const { data, mutate } = useSWR<UnwrapFunc<typeof postSignGitHubMarketAsset>, Error>(
-    SWRCachePath.postSignGitHubMarketAsset()
-  )
+  const { data } = useSWR<UnwrapFunc<typeof postSignGitHubMarketAsset>, Error>(SWRCachePath.postSignGitHubMarketAsset())
 
   const postSignGitHubMarketAssetHandler = async (repository: string, personalAccessToken: string) => {
     const signMessage = repository

--- a/packages/web/src/fixtures/khaos/hooks.ts
+++ b/packages/web/src/fixtures/khaos/hooks.ts
@@ -15,13 +15,16 @@ export const usePostSignGitHubMarketAsset = () => {
 
   const postSignGitHubMarketAssetHandler = async (repository: string, personalAccessToken: string) => {
     const signMessage = repository
-    const signature = (await sign(signMessage)) || ''
+    const signature = await sign(signMessage)
+    if (signature === undefined) {
+      message.error({ content: 'Please connect to a wallet', key: key + 'WithWallet' })
+    }
 
     setIsLoading(true)
     message.loading({ content: 'authenticate asset', duration: 0, key })
 
     await mutate(
-      postSignGitHubMarketAsset(signMessage, signature, personalAccessToken)
+      postSignGitHubMarketAsset(signMessage, signature || '', personalAccessToken)
         .then(result => {
           message.success({ content: 'success to authenticate asset', key })
           setIsLoading(false)

--- a/packages/web/src/fixtures/khaos/hooks.ts
+++ b/packages/web/src/fixtures/khaos/hooks.ts
@@ -23,25 +23,22 @@ export const usePostSignGitHubMarketAsset = () => {
     setIsLoading(true)
     message.loading({ content: 'authenticate asset', duration: 0, key })
 
-    await mutate(
-      postSignGitHubMarketAsset(signMessage, signature || '', personalAccessToken)
-        .then(result => {
-          setIsLoading(false)
-          if (result instanceof Error) {
-            message.error({ content: result.message, key })
-            return {} as GitHubAssetInformation
-          } else {
-            message.success({ content: 'success to authenticate asset', key })
-            return result
-          }
-        })
-        .catch(err => {
-          message.error({ content: err.message, key })
-          setIsLoading(false)
-          return Promise.reject(err)
-        }),
-      false
-    )
+    return postSignGitHubMarketAsset(signMessage, signature || '', personalAccessToken)
+      .then(result => {
+        setIsLoading(false)
+        if (result instanceof Error) {
+          message.error({ content: result.message, key })
+          return {} as GitHubAssetInformation
+        } else {
+          message.success({ content: 'success to authenticate asset', key })
+          return result
+        }
+      })
+      .catch(err => {
+        message.error({ content: err.message, key })
+        setIsLoading(false)
+        return Promise.reject(err)
+      })
   }
 
   return { data, postSignGitHubMarketAssetHandler, isLoading }

--- a/packages/web/src/fixtures/khaos/hooks.ts
+++ b/packages/web/src/fixtures/khaos/hooks.ts
@@ -1,0 +1,35 @@
+import useSWR from 'swr'
+import { message } from 'antd'
+import { UnwrapFunc } from '../utility'
+import { SWRCachePath } from './cache-path'
+import { postSignGitHubMarketAsset } from './utility'
+import { sign } from 'src/fixtures/wallet/utility'
+
+export const usePostSignGitHubMarketAsset = () => {
+  const key = 'usePostSignGitHubMarketAsset'
+  const { data, mutate } = useSWR<UnwrapFunc<typeof postSignGitHubMarketAsset>, Error>(
+    SWRCachePath.postSignGitHubMarketAsset()
+  )
+
+  const postSignGitHubMarketAssetHandler = async (repository: string, publicAccessToken: string) => {
+    const signMessage = repository
+    const signature = (await sign(signMessage)) || ''
+
+    message.loading({ content: 'authenticate asset', duration: 0, key })
+
+    await mutate(
+      postSignGitHubMarketAsset(signMessage, signature, publicAccessToken)
+        .then(result => {
+          message.success({ content: 'success to authenticate asset', key })
+          return result
+        })
+        .catch(err => {
+          message.error({ content: err.message, key })
+          return Promise.reject(data)
+        }),
+      false
+    )
+  }
+
+  return { data, postSignGitHubMarketAssetHandler }
+}

--- a/packages/web/src/fixtures/khaos/utility.ts
+++ b/packages/web/src/fixtures/khaos/utility.ts
@@ -20,4 +20,10 @@ export const postSignGitHubMarketAsset = (
       secret: personalAccessToken,
       message: signMessage
     })
-  }).then(res => res.json())
+  }).then(res => {
+    if (res.ok) {
+      return res.json()
+    } else {
+      return Promise.resolve(Error('fail to sign github market asset'))
+    }
+  })

--- a/packages/web/src/fixtures/khaos/utility.ts
+++ b/packages/web/src/fixtures/khaos/utility.ts
@@ -8,7 +8,7 @@ export interface GitHubAssetInformation {
 export const postSignGitHubMarketAsset = (
   signMessage: string,
   signature: string,
-  publicAccessToken: string
+  personalAccessToken: string
 ): Promise<GitHubAssetInformation> =>
   fetch(`${BaseUrl}/sign/github-market`, {
     method: 'POST',
@@ -17,7 +17,7 @@ export const postSignGitHubMarketAsset = (
     },
     body: JSON.stringify({
       signature: signature,
-      secret: publicAccessToken,
+      secret: personalAccessToken,
       message: signMessage
     })
   }).then(res => res.json())

--- a/packages/web/src/fixtures/khaos/utility.ts
+++ b/packages/web/src/fixtures/khaos/utility.ts
@@ -1,0 +1,23 @@
+import { BaseUrl } from './cache-path'
+
+export interface GitHubAssetInformation {
+  address: string
+  publicSignature: string
+}
+
+export const postSignGitHubMarketAsset = (
+  signMessage: string,
+  signature: string,
+  publicAccessToken: string
+): Promise<GitHubAssetInformation> =>
+  fetch(`${BaseUrl}/sign/github-market`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8'
+    },
+    body: JSON.stringify({
+      signature: signature,
+      secret: publicAccessToken,
+      message: signMessage
+    })
+  }).then(res => res.json())


### PR DESCRIPTION
## Proposed Changes
support GitHub market.
The input values for authentication are repository name (ex. `dev-protocol/stakes.social`) and github personal access token.

## Implementation
* Separate AuthForm by npm market and other(github) markets
* For other markets, authenticate the Asset via Khaos
* switch Khaos Endpoint URL for mainnet and ropsten by NODE_ENV