### PR TITLE
add Invitation Request Page

### DIFF
--- a/packages/web/src/components/organisms/AuthForm/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/AuthForm/__snapshots__/index.spec.tsx.snap
@@ -48,7 +48,7 @@ exports[`AuthForm Snapshot 1`] = `
           <p>
             <a
               class="ant-btn ant-btn-primary"
-              href="https://forms.gle/MVxEvdPNNig9YdBu6"
+              href="/invite/github"
               target="_blank"
             >
               <span>

--- a/packages/web/src/components/organisms/AuthForm/index.tsx
+++ b/packages/web/src/components/organisms/AuthForm/index.tsx
@@ -76,7 +76,7 @@ const Notify = () => (
       <>
         <p>Please send our team an invitation request via the form.</p>
         <p>
-          <Button type="primary" href="https://forms.gle/MVxEvdPNNig9YdBu6" target="_blank">
+          <Button type="primary" href="/invite/github" target="_blank">
             Apply form
           </Button>
         </p>

--- a/packages/web/src/components/organisms/InvitationRequestForm/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/InvitationRequestForm/__snapshots__/index.spec.tsx.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InvitationRequestForm Snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="dhltmz-0 fMwGGH"
+    >
+      <div
+        class="dhltmz-1 cVAoyt"
+      >
+        <span>
+          Associating Market:
+        </span>
+        <span>
+          market
+        </span>
+      </div>
+      <div
+        class="dhltmz-1 cVAoyt"
+      >
+        <span>
+          Arguments:
+        </span>
+        <form
+          class="ant-form ant-form-horizontal"
+          id="basic"
+        >
+          <div
+            class="ant-row ant-form-item"
+          >
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <input
+                    class="ant-input"
+                    id="basic_asset"
+                    placeholder="asset name"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-row ant-form-item"
+          >
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <input
+                    class="ant-input"
+                    id="basic_email"
+                    placeholder="email address"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-row ant-form-item"
+          >
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <input
+                    class="ant-input"
+                    id="basic_discord"
+                    placeholder="discord profile name"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <button
+            class="ant-btn ant-btn-primary"
+            type="submit"
+          >
+            <span>
+              Invitation Request
+            </span>
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/web/src/components/organisms/InvitationRequestForm/index.spec.tsx
+++ b/packages/web/src/components/organisms/InvitationRequestForm/index.spec.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { InvitationRequestForm } from '.'
+import 'src/__mocks__/window/matchMedia.mock'
+import { useEffectAsync } from 'src/fixtures/utility'
+
+jest.mock('src/fixtures/utility')
+jest.mock('src/fixtures/dev-kit/hooks')
+
+describe(`${InvitationRequestForm.name}`, () => {
+  test('Snapshot', () => {
+    ;(useEffectAsync as jest.Mock).mockImplementation(() => {})
+    const component = render(<InvitationRequestForm market="market" />)
+    const tree = component.baseElement
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/packages/web/src/components/organisms/InvitationRequestForm/index.tsx
+++ b/packages/web/src/components/organisms/InvitationRequestForm/index.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react'
+import { Form, Input, Button, Result } from 'antd'
+import styled from 'styled-components'
+import { usePostInvitation } from 'src/fixtures/dev-invitation/hooks'
+
+export interface Props {
+  market: string
+}
+
+const Wrap = styled.div`
+  display: grid;
+  grid-gap: 1rem;
+`
+const Row = styled.div`
+  display: grid;
+  grid-gap: 1rem;
+  @media (min-width: 768px) {
+    grid-template-columns: 150px 1fr;
+    & > *:first-child {
+      text-align: right;
+    }
+  }
+`
+
+export const InvitationRequestForm = ({ market }: Props) => {
+  const [metrics, setMetrics] = useState<boolean>(false)
+  const { postInvitationHandler, isLoading } = usePostInvitation(market)
+  const onFinish = async (values: any) => {
+    const { asset, email, discord } = values
+    const metrics = await postInvitationHandler(asset, email, discord)
+
+    if (metrics.success) {
+      setMetrics(metrics.success)
+    }
+  }
+
+  return (
+    <Wrap>
+      <Row>
+        <span>Associating Market:</span>
+        <span>{market}</span>
+      </Row>
+      {metrics ? (
+        <Result status="success" title="Successfully Invitation Request Your Asset!" subTitle="" />
+      ) : (
+        <Row>
+          <span>Arguments:</span>
+          <Form name="basic" initialValues={{ remember: true }} onFinish={onFinish}>
+            <Form.Item
+              name="asset"
+              rules={[{ required: true, message: 'Please input asset name (e.g., your/awesome-repos)' }]}
+              key="asset"
+            >
+              <Input placeholder="asset name" />
+            </Form.Item>
+            <Form.Item name="email" rules={[{ required: true, type: 'email' }]} key="email">
+              <Input placeholder="email address" />
+            </Form.Item>
+            <Form.Item name="discord" rules={[{ required: true, type: 'string' }]} key="discord">
+              <Input placeholder="discord profile name" />
+            </Form.Item>
+            <Button type="primary" htmlType="submit" loading={isLoading} disabled={isLoading}>
+              Invitation Request
+            </Button>
+          </Form>
+        </Row>
+      )}
+    </Wrap>
+  )
+}

--- a/packages/web/src/fixtures/dev-invitation/cache-path.ts
+++ b/packages/web/src/fixtures/dev-invitation/cache-path.ts
@@ -1,0 +1,5 @@
+export const BaseUrl = 'https://dev-invitation.azurewebsites.net/api'
+
+export const SWRCachePath = {
+  postInvitation: () => `${BaseUrl}/invitation`
+} as const

--- a/packages/web/src/fixtures/dev-invitation/hooks.spec.ts
+++ b/packages/web/src/fixtures/dev-invitation/hooks.spec.ts
@@ -1,0 +1,69 @@
+import useSWR from 'swr'
+import { renderHook, act } from '@testing-library/react-hooks'
+import { usePostInvitation } from './hooks'
+import { postInvitation } from './utility'
+import { sign } from 'src/fixtures/wallet/utility'
+
+jest.mock('swr')
+jest.mock('src/fixtures/utility')
+jest.mock('src/fixtures/dev-invitation/utility.ts')
+jest.mock('src/fixtures/wallet/utility.ts')
+
+describe('dev-invitation hooks', () => {
+  describe('usePostInvitation', () => {
+    test('success invitation request', async () => {
+      const data = { success: true }
+      const error = undefined
+      ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error, mutate: () => {} }))
+      ;(sign as jest.Mock).mockResolvedValue('dummy signature')
+      ;(postInvitation as jest.Mock).mockResolvedValue(data)
+      const { result } = renderHook(() => usePostInvitation('dummy market'))
+      expect(result.current.data).toBe(data)
+      await act(async () => {
+        const asset = 'dummy asset'
+        const email = 'dummy@dummy.com'
+        const discord = 'dummy-discord'
+        const ret = await result.current.postInvitationHandler(asset, email, discord)
+        expect(ret).toBe(data)
+      })
+    })
+
+    test('failure invitation request', async () => {
+      const data = undefined
+      const error = new Error('error')
+      ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error, mutate: () => {} }))
+      ;(sign as jest.Mock).mockResolvedValue('dummy signature')
+      ;(postInvitation as jest.Mock).mockResolvedValue({ success: false })
+      const { result } = renderHook(() => usePostInvitation('dummy market'))
+      await act(async () => {
+        const asset = 'dummy asset'
+        const email = 'dummy@dummy.com'
+        const discord = 'dummy-discord'
+        const ret = await result.current.postInvitationHandler(asset, email, discord)
+        expect(ret.success).toBe(false)
+      })
+      expect(result.current.isLoading).toBe(false)
+      expect(postInvitation).toHaveBeenCalledTimes(1)
+    })
+
+    test('failure invitation request with fail web3 sign', async () => {
+      const data = undefined
+      const error = new Error('error')
+      ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error, mutate: () => {} }))
+      ;(sign as jest.Mock).mockResolvedValue(undefined)
+      ;(postInvitation as jest.Mock).mockResolvedValue({ success: true })
+      const { result } = renderHook(() => usePostInvitation('dummy market'))
+      await act(async () => {
+        const asset = 'dummy asset'
+        const email = 'dummy@dummy.com'
+        const discord = 'dummy-discord'
+        const ret = await result.current.postInvitationHandler(asset, email, discord)
+        expect(ret.success).toBe(false)
+      })
+      expect(result.current.isLoading).toBe(false)
+
+      // early return, not call postInvitation request.
+      expect(postInvitation).toHaveBeenCalledTimes(0)
+    })
+  })
+})

--- a/packages/web/src/fixtures/dev-invitation/hooks.ts
+++ b/packages/web/src/fixtures/dev-invitation/hooks.ts
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { SWRCachePath } from './cache-path'
+import useSWR from 'swr'
+import { message } from 'antd'
+import { UnwrapFunc } from '../utility'
+import { postInvitation } from './utility'
+import { sign } from 'src/fixtures/wallet/utility'
+
+export const usePostInvitation = (marketAddress: string) => {
+  const key = 'usePostInvitation'
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+
+  const shouldFetch = marketAddress !== ''
+  const { data } = useSWR<UnwrapFunc<typeof postInvitation>, Error>(shouldFetch ? SWRCachePath.postInvitation() : null)
+
+  const postInvitationHandler = async (asset: string, email: string, discord: string) => {
+    const signMessage = `invitation: ${asset}`
+    const signature = await sign(signMessage)
+    if (signature === undefined) {
+      message.error({ content: 'Please connect to a wallet', key: key + 'WithWallet' })
+      return { success: false }
+    }
+
+    setIsLoading(true)
+    message.loading({ content: 'invitation request...', duration: 0, key })
+
+    return postInvitation(asset, email, discord, signMessage, marketAddress, signature)
+      .then(result => {
+        if (result.success) {
+          message.success({ content: 'success', key })
+        } else {
+          message.error({ content: 'error', key })
+        }
+        setIsLoading(false)
+        return result
+      })
+      .catch(err => {
+        message.error({ content: err.message, key })
+        setIsLoading(false)
+        return Promise.reject(err)
+      })
+  }
+
+  return { data, postInvitationHandler, isLoading }
+}

--- a/packages/web/src/fixtures/dev-invitation/utility.ts
+++ b/packages/web/src/fixtures/dev-invitation/utility.ts
@@ -1,0 +1,28 @@
+import { BaseUrl } from './cache-path'
+
+export interface InvitationResult {
+  success: boolean
+}
+
+export const postInvitation = (
+  asset: string,
+  email: string,
+  discord: string,
+  signMessage: string,
+  marketAddress: string,
+  signature?: string
+): Promise<InvitationResult> =>
+  fetch(`${BaseUrl}/invitation`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8'
+    },
+    body: JSON.stringify({
+      asset: asset,
+      email: email,
+      discord: discord,
+      signature: signature,
+      message: signMessage,
+      market: marketAddress
+    })
+  }).then(res => res.json())

--- a/packages/web/src/pages/invite/[market]/index.tsx
+++ b/packages/web/src/pages/invite/[market]/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { useRouter } from 'next/router'
+import { InvitationRequestForm } from 'src/components/organisms/InvitationRequestForm'
+import { Footer } from 'src/components/organisms/Footer'
+import { Header } from 'src/components/organisms/Header'
+import { Headline } from 'src/components/atoms/Headline'
+import { H2 } from 'src/components/atoms/Typography'
+import styled from 'styled-components'
+
+type Props = {}
+
+const WrapContainer = styled.div`
+  max-width: 760px;
+  margin: auto;
+  padding: 1rem;
+  word-break: break-all;
+`
+
+const InvitationRequest = (_: Props) => {
+  const { market } = useRouter().query as { market: string }
+
+  return (
+    <>
+      <Header />
+      <Headline height={300}>
+        <H2>Invitation Request</H2>
+      </Headline>
+      <WrapContainer>
+        <InvitationRequestForm market={market} />
+      </WrapContainer>
+      <Footer />
+    </>
+  )
+}
+
+export default InvitationRequest


### PR DESCRIPTION
## Proposed Changes
Instead of the google form, have a dedicated page in Stakes.social.
![invitation-request-page](https://user-images.githubusercontent.com/150309/91853254-e6d51900-ec9c-11ea-9593-7c9755412b0a.png)

## Implementation
* route to `/invite/[market]`
* If GitHub market is selected in AuthForm, it's linked to `/invite/github` fixed
* add fixture as `dev-invitation`