### PR TITLE
fix: viewport meta should not be used in _document.js

### DIFF
--- a/packages/web/src/pages/_app.tsx
+++ b/packages/web/src/pages/_app.tsx
@@ -70,7 +70,8 @@ class NextApp extends App<AppInitialProps & WithApolloProps<{}>> {
       <>
         <Head>
           <title>Stakes.social</title>
-          <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+          {/* Use minimum-scale=1 to enable GPU rasterization */}
+          <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no" />
         </Head>
         <Component {...pageProps} apollo={apollo} />
         <HelpUs></HelpUs>

--- a/packages/web/src/pages/_document.tsx
+++ b/packages/web/src/pages/_document.tsx
@@ -28,8 +28,6 @@ export default class extends Document {
       <html lang="ja">
         <Head>
           <meta charSet="utf-8" />
-          {/* Use minimum-scale=1 to enable GPU rasterization */}
-          <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no" />
           <link rel="stylesheet" href="https://use.typekit.net/owg1uzy.css" />
           <link rel="apple-touch-icon" sizes="57x57" href="//asset.stakes.social/apple-icon-57x57.png" />
           <link rel="apple-touch-icon" sizes="60x60" href="//asset.stakes.social/apple-icon-60x60.png" />


### PR DESCRIPTION
## Proposed Changes
Changes to suppress the following warning:
```
Warning: viewport meta tags should not be used in _document.js's <Head>. https://err.sh/next.js/no-document-viewport-meta
```
https://github.com/vercel/next.js/blob/master/errors/no-document-viewport-meta.md

## Implementation
* delete to `viewport` meta in `src/pages/_document.tsx`, and unified at `src/pages/_app.tsx`.