### PR TITLE
use next/document Html component

### DIFF
--- a/packages/web/src/pages/_document.tsx
+++ b/packages/web/src/pages/_document.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Document, { Head, Main, NextScript, DocumentContext } from 'next/document'
+import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
 
 export default class extends Document {
@@ -25,7 +25,7 @@ export default class extends Document {
 
   render() {
     return (
-      <html lang="ja">
+      <Html lang="ja">
         <Head>
           <meta charSet="utf-8" />
           {/* Use minimum-scale=1 to enable GPU rasterization */}
@@ -53,7 +53,7 @@ export default class extends Document {
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     )
   }
 }


### PR DESCRIPTION
## Proposed Changes
Follow the practices described below
https://nextjs.org/docs/advanced-features/custom-document

As a result, suppress the following warning:
```
warn  - Your custom Document (pages/_document) did not render all the required subcomponent.
Missing component: <Html />
```

## Implementation
* change from raw `html` tag to `next/document`'s `Html` component