### PR TITLE
Cache web3 signature

### DIFF
--- a/packages/web/src/fixtures/dev-for-apps/__mocks__/hooks.ts
+++ b/packages/web/src/fixtures/dev-for-apps/__mocks__/hooks.ts
@@ -1,17 +1,3 @@
-export const useGetUser = () => {
-  return {
-    displayName: 'Get Your Display Name'
-  }
-}
-
-export const usePostUser = () => {
-  return {
-    usePostUser: async () => {
-      return { displayName: 'Post Your Display Name' }
-    }
-  }
-}
-
 export const useGetPropertyTags = () => {
   return {
     tags: ['dummy', 'tag']

--- a/packages/web/src/fixtures/dev-for-apps/functions/useUploadFile.spec.ts
+++ b/packages/web/src/fixtures/dev-for-apps/functions/useUploadFile.spec.ts
@@ -2,7 +2,7 @@ import useSWR from 'swr'
 import { renderHook, act } from '@testing-library/react-hooks'
 import { useUploadFile } from './useUploadFile'
 import { postUploadFile } from '../utility'
-import { sign } from 'src/fixtures/wallet/utility'
+import { signWithCache } from 'src/fixtures/wallet/utility'
 
 jest.mock('swr')
 jest.mock('src/fixtures/utility')
@@ -14,7 +14,10 @@ describe('useUploadFile', () => {
   test('success post file', async () => {
     ;(useSWR as jest.Mock).mockImplementation(() => ({ mutate: () => {} }))
     ;(postUploadFile as jest.Mock).mockResolvedValue({ id: 'id' })
-    ;(sign as jest.Mock).mockImplementation(() => 'test sign message')
+    ;(signWithCache as jest.Mock).mockImplementation(() => ({
+      signature: 'test signature',
+      message: 'test sign message'
+    }))
     const { result, waitForNextUpdate } = renderHook(() => useUploadFile('0x01234567890'))
     act(() => {
       result.current.postUploadFileHandler(1, 'ref', 'field', {}, '/path')
@@ -28,7 +31,10 @@ describe('useUploadFile', () => {
     const error = new Error(errorMessage)
     ;(useSWR as jest.Mock).mockImplementation(() => ({ mutate: () => {} }))
     ;(postUploadFile as jest.Mock).mockRejectedValue(error)
-    ;(sign as jest.Mock).mockImplementation(() => 'test sign message')
+    ;(signWithCache as jest.Mock).mockImplementation(() => ({
+      signature: 'test signature',
+      message: 'test sign message'
+    }))
     const { result, waitForNextUpdate } = renderHook(() => useUploadFile('0x01234567890'))
     act(() => {
       result.current.postUploadFileHandler(1, 'ref', 'field', {}, '/path')
@@ -36,5 +42,19 @@ describe('useUploadFile', () => {
     await waitForNextUpdate()
     expect(result.current.isLoading).toBe(false)
     expect(result.current.error?.message).toBe(errorMessage)
+    expect((postUploadFile as jest.Mock).mock.calls.length).toBe(1)
+  })
+
+  test('failure post file with web3.sign error', async () => {
+    const errorMessage = 'error'
+    const error = new Error(errorMessage)
+    ;(useSWR as jest.Mock).mockImplementation(() => ({ mutate: () => {} }))
+    ;(postUploadFile as jest.Mock).mockRejectedValue(error)
+    ;(signWithCache as jest.Mock).mockImplementation(() => ({ signature: undefined, message: undefined }))
+    const { result } = renderHook(() => useUploadFile('0x01234567890'))
+    const v = await result.current.postUploadFileHandler(1, 'ref', 'field', {}, '/path')
+    expect(result.current.isLoading).toBe(false)
+    expect(v).toBe(undefined)
+    expect((postUploadFile as jest.Mock).mock.calls.length).toBe(0)
   })
 })

--- a/packages/web/src/fixtures/dev-for-apps/functions/useUploadFile.ts
+++ b/packages/web/src/fixtures/dev-for-apps/functions/useUploadFile.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { message } from 'antd'
 import { postUploadFile } from '../utility'
-import { sign } from 'src/fixtures/wallet/utility'
+import { signWithCache } from 'src/fixtures/wallet/utility'
 import { useProvider } from '../../wallet/hooks'
 
 export const useUploadFile = (accountAddress: string) => {
@@ -12,15 +12,15 @@ export const useUploadFile = (accountAddress: string) => {
 
   const postUploadFileHandler = async (refId: number, ref: string, field: string, file: any, path?: string) => {
     const signMessage = `upload file: ${refId}, ${ref}, ${field}`
-    const signature = (await sign(web3, signMessage)) || ''
-    if (!signature) {
+    const { signature, message: signedMessage } = await signWithCache(web3, signMessage)
+    if (!signature || !signedMessage) {
       return
     }
 
     setIsLoading(true)
     message.loading({ content: 'upload data...', duration: 0, key })
 
-    const res = postUploadFile(signMessage, signature, accountAddress, refId, ref, field, file, path)
+    const res = postUploadFile(signedMessage, signature, accountAddress, refId, ref, field, file, path)
       .then(result => {
         if (result.error) {
           message.error({ content: result.error, key })

--- a/packages/web/src/fixtures/dev-for-apps/hooks.spec.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.spec.ts
@@ -53,20 +53,22 @@ describe('dev-for-apps hooks for property tags', () => {
       expect(result.current.data).toBe(data)
     })
 
-    test('failure post property tags', async () => {
+    test('failure post property tags with web3.sign error', async () => {
       const propertyAddress = '0x01234567890'
       const accountAddress = '0x09876543210'
       const data = undefined
       const errorMessage = 'error'
       const error = new Error(errorMessage)
       ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error, mutate: () => {} }))
-      ;(postPropertyTags as jest.Mock).mockResolvedValue({ tags: ['dummy', 'post', 'tag'] })
-      const { result, waitForNextUpdate } = renderHook(() => usePostPropertyTags(propertyAddress, accountAddress))
-      act(() => {
+      ;(signWithCache as jest.Mock).mockImplementation(() => ({ signature: undefined, message: undefined }))
+      ;(postPropertyTags as jest.Mock).mockImplementation(() => {})
+      const { result } = renderHook(() => usePostPropertyTags(propertyAddress, accountAddress))
+      await act(() => {
         result.current.postPropertyTagsHandler('dummy tags')
       })
-      await waitForNextUpdate()
       expect(result.current.isLoading).toBe(false)
+      expect(result.current.data).toBe(undefined)
+      expect((postPropertyTags as jest.Mock).mock.calls.length).toBe(0)
     })
   })
 })

--- a/packages/web/src/fixtures/dev-for-apps/hooks.spec.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.spec.ts
@@ -1,16 +1,14 @@
 import useSWR from 'swr'
 import { renderHook, act } from '@testing-library/react-hooks'
 import {
-  useGetUser,
-  usePostUser,
   useGetPropertyTags,
   usePostPropertyTags,
   useGetProperty,
   useUploadAccountAvatar,
   useUploadAccountCoverImages
 } from './hooks'
-import { postUser, postPropertyTags } from './utility'
-import { sign } from 'src/fixtures/wallet/utility'
+import { postPropertyTags } from './utility'
+import { signWithCache } from 'src/fixtures/wallet/utility'
 import { useUploadFile } from './functions/useUploadFile'
 import { useGetAccount } from './functions/useGetAccount'
 
@@ -21,54 +19,6 @@ jest.mock('src/fixtures/wallet/utility.ts')
 jest.mock('src/fixtures/wallet/hooks.ts')
 jest.mock('src/fixtures/dev-for-apps/functions/useUploadFile')
 jest.mock('src/fixtures/dev-for-apps/functions/useGetAccount')
-
-describe('dev-for-apps hooks for user profile', () => {
-  describe('useGetUser', () => {
-    test('success get profile', async () => {
-      const data = { displayName: 'Get Your Dispaly Name' }
-      const error = undefined
-      ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error }))
-      const { result } = renderHook(() => useGetUser('0x01234567890'))
-      expect(result.current.data).toBe(data)
-    })
-
-    test('failure get profile', async () => {
-      const data = undefined
-      const errorMessage = 'error'
-      const error = new Error(errorMessage)
-      ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error }))
-      const { result } = renderHook(() => useGetUser('0x01234567890'))
-      expect(result.current.error).toBe(error)
-      expect(result.current.error?.message).toBe(errorMessage)
-    })
-  })
-
-  describe('usePostUser', () => {
-    test('success post profile', async () => {
-      const data = { displayName: 'Posted Your Dispaly Name' }
-      const error = undefined
-      ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error, mutate: () => {} }))
-      ;(postUser as jest.Mock).mockResolvedValue({ displayName: 'name' })
-      const { result } = renderHook(() => usePostUser('0x01234567890'))
-      expect(result.current.data).toBe(data)
-    })
-
-    test('failure post profile', async () => {
-      const data = undefined
-      const errorMessage = 'error'
-      const error = new Error(errorMessage)
-      ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error, mutate: () => {} }))
-      ;(postUser as jest.Mock).mockResolvedValue({ displayName: 'name' })
-      ;(sign as jest.Mock).mockImplementation(() => 'test sign message')
-      const { result, waitForNextUpdate } = renderHook(() => usePostUser('0x01234567890'))
-      act(() => {
-        result.current.postUserHandler('dummy')
-      })
-      await waitForNextUpdate()
-      expect(result.current.isLoading).toBe(false)
-    })
-  })
-})
 
 describe('dev-for-apps hooks for property tags', () => {
   describe('useGetPropertyTags', () => {

--- a/packages/web/src/fixtures/dev-for-apps/hooks.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.ts
@@ -3,62 +3,13 @@ import { SWRCachePath } from './cache-path'
 import useSWR, { mutate } from 'swr'
 import { message } from 'antd'
 import { UnwrapFunc, whenDefined } from '../utility'
-import { getUser, postUser, getPropertyTags, postPropertyTags, postAccount, putAccount, getProperty } from './utility'
-import { sign } from 'src/fixtures/wallet/utility'
+import { getPropertyTags, postPropertyTags, postAccount, putAccount, getProperty } from './utility'
+import { signWithCache } from 'src/fixtures/wallet/utility'
 import { useProvider } from '../wallet/hooks'
 import { useUploadFile } from './functions/useUploadFile'
 import { useGetAccount } from './functions/useGetAccount'
 
 export { useUploadFile, useGetAccount }
-
-export const useGetUser = (walletAddress: string) => {
-  const shouldFetch = walletAddress !== ''
-  const { data, error, mutate } = useSWR<UnwrapFunc<typeof getUser>, Error>(
-    shouldFetch ? SWRCachePath.getUser(walletAddress) : null,
-    () => getUser(walletAddress),
-    { onError: err => message.error(err.message) }
-  )
-  return { data, error, mutate }
-}
-
-export const usePostUser = (walletAddress: string) => {
-  const key = 'useGetUser'
-  const { web3 } = useProvider()
-  const [isLoading, setIsLoading] = useState<boolean>(false)
-
-  const shouldFetch = walletAddress !== ''
-  const { data, mutate } = useSWR<UnwrapFunc<typeof getUser>, Error>(
-    shouldFetch ? SWRCachePath.getUser(walletAddress) : null
-  )
-
-  const postUserHandler = async (name: string) => {
-    const signMessage = `submit display name: ${name}`
-    const signature = (await sign(web3, signMessage)) || ''
-    if (!signature) {
-      return
-    }
-
-    setIsLoading(true)
-    message.loading({ content: 'update display name...', duration: 0, key })
-
-    await mutate(
-      postUser(name, signMessage, signature, walletAddress)
-        .then(result => {
-          message.success({ content: 'success update display name', key })
-          return result
-        })
-        .catch(err => {
-          message.error({ content: err.message, key })
-          return Promise.reject(data)
-        }),
-      false
-    )
-
-    setIsLoading(false)
-  }
-
-  return { data, postUserHandler, isLoading }
-}
 
 export const useGetPropertyTags = (propertyAddress: string) => {
   const shouldFetch = propertyAddress !== ''

--- a/packages/web/src/fixtures/dev-for-apps/hooks.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.ts
@@ -81,8 +81,8 @@ export const usePostPropertyTags = (propertyAddress: string, walletAddress: stri
 
   const postPropertyTagsHandler = async (tags: string) => {
     const signMessage = `submit property tags: ${tags}`
-    const signature = (await sign(web3, signMessage)) || ''
-    if (!signature) {
+    const { signature, message: signedMessage } = await signWithCache(web3, signMessage)
+    if (!signature || !signedMessage) {
       return
     }
 
@@ -90,7 +90,7 @@ export const usePostPropertyTags = (propertyAddress: string, walletAddress: stri
     message.loading({ content: 'update property tags...', duration: 0, key })
 
     await mutate(
-      postPropertyTags(propertyAddress, tags, signMessage, signature, walletAddress)
+      postPropertyTags(propertyAddress, tags, signedMessage, signature, walletAddress)
         .then(result => {
           message.success({ content: 'success update property tags', key })
           return result
@@ -121,8 +121,8 @@ export const useCreateAccount = (walletAddress: string) => {
 
   const postAccountHandler = async (name?: string, biography?: string) => {
     const signMessage = `create accout: ${name}, ${biography}`
-    const signature = (await sign(web3, signMessage)) || ''
-    if (!signature) {
+    const { signature, message: signedMessage } = await signWithCache(web3, signMessage)
+    if (!signature || !signedMessage) {
       return
     }
 
@@ -130,7 +130,7 @@ export const useCreateAccount = (walletAddress: string) => {
     message.loading({ content: 'update account data...', duration: 0, key })
 
     await mutate(
-      postAccount(signMessage, signature, walletAddress, name, biography)
+      postAccount(signedMessage, signature, walletAddress, name, biography)
         .then(result => {
           message.success({ content: 'success update account data', key })
           return result
@@ -160,8 +160,8 @@ export const useUpdateAccount = (id: number, walletAddress: string) => {
 
   const putAccountHandler = async (name?: string, biography?: string) => {
     const signMessage = `update accout: ${name}, ${biography}`
-    const signature = (await sign(web3, signMessage)) || ''
-    if (!signature) {
+    const { signature, message: signedMessage } = await signWithCache(web3, signMessage)
+    if (!signature || !signedMessage) {
       return
     }
 
@@ -169,7 +169,7 @@ export const useUpdateAccount = (id: number, walletAddress: string) => {
     message.loading({ content: 'update account data...', duration: 0, key })
 
     await mutate(
-      putAccount(signMessage, signature, walletAddress, id, name, biography)
+      putAccount(signedMessage, signature, walletAddress, id, name, biography)
         .then(result => {
           message.success({ content: 'success update account data', key })
           return result


### PR DESCRIPTION
## Proposed Changes
Now, need to authenticate to update the profile, and sign and authenticate with web3.sign every time.

Since UX is not so good, I will change to a form that authenticates only once and then caches the result of the first authentication and authenticates using it.
This cache is invalidated by a browser reload and only used for profile updates.

## Implementation
* add `signWithCache` function that can use the cache that extends the function `sign` for web3.sign
  * `signWithCache` returns the cache signature and message if there is a cache
  * If there is no cache, `signWithCache` returns the web3.signed signature and the input message
* remove the old endpoint (a.k.a dev-for-apps v1) interface for updating the profile
