### PR TITLE
Fix withdraw value

### DIFF
--- a/packages/web/src/components/organisms/TransactionForm/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/TransactionForm/__snapshots__/index.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`TransactionForm Snapshot 1`] = `
           Withdraw 
           Stakers
            Reward 
-          0
+          3000
            
           DEV
            available

--- a/packages/web/src/components/organisms/Withdraw/WithdrawWithEstimate.tsx
+++ b/packages/web/src/components/organisms/Withdraw/WithdrawWithEstimate.tsx
@@ -16,7 +16,7 @@ export const WithdrawWithEstimate = ({ className, title, propertyAddress }: Prop
   const [claimedTokens, setClaimedTokens] = useState<string | undefined>()
   const [interestTokens, setInterestTokens] = useState<string | undefined>()
   const [withdrawableTokens, setWithdrawableTokens] = useState<string>('')
-  const { myStakingRewardAmount } = useGetMyStakingRewardAmount(propertyAddress)
+  const { dev: myStakingRewardAmount } = useGetMyStakingRewardAmount(propertyAddress)
   const { myStakingAmount } = useGetMyStakingAmount(propertyAddress)
 
   const estimatedValue = useMemo(

--- a/packages/web/src/components/organisms/Withdraw/__snapshots__/WithdrawWithEstimate.spec.tsx.snap
+++ b/packages/web/src/components/organisms/Withdraw/__snapshots__/WithdrawWithEstimate.spec.tsx.snap
@@ -73,9 +73,9 @@ exports[`WithdrawWithEstimate Snapshot 1`] = `
           class="ant-card-body"
         >
           <p>
-            5000
+            3000
              DEV 
-            (0 + 5000)
+            (0 + 3000)
           </p>
         </div>
       </div>

--- a/packages/web/src/fixtures/dev-kit/__mocks__/hooks.ts
+++ b/packages/web/src/fixtures/dev-kit/__mocks__/hooks.ts
@@ -13,7 +13,7 @@ export const useGetMyHolderAmount = () => {
 }
 
 export const useGetMyStakingRewardAmount = () => {
-  return { myStakingRewardAmount: new BigNumber(5000) }
+  return { myStakingRewardAmount: new BigNumber(5000), dev: new BigNumber(3000) }
 }
 
 export const useGetMyStakingAmount = () => {


### PR DESCRIPTION
## Proposed Changes
<img width="1929" alt="fix-withdrawal-value" src="https://user-images.githubusercontent.com/150309/100180774-4483a500-2f1c-11eb-99fe-bebed194ca3f.png">

On the screen above, the original reward DEV value is 3.xx.
When the display currency is set to USD, it is displayed in USD value.

This issue only occurs in the preview version.

## Implementation
* The value of withdraw has been modified to be forcibly displayed as DEV