### PR TITLE
Author Profile edit page

### DIFF
--- a/packages/web/src/components/atoms/FullpageWrap/index.tsx
+++ b/packages/web/src/components/atoms/FullpageWrap/index.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+import { Grid } from '../Grid'
+
+export const FullpageWrap = styled(Grid)`
+  min-height: 100vh;
+  align-content: space-between;
+`

--- a/packages/web/src/fixtures/dev-for-apps/functions/useGetAccount.spec.ts
+++ b/packages/web/src/fixtures/dev-for-apps/functions/useGetAccount.spec.ts
@@ -10,14 +10,24 @@ describe('useGetAccount', () => {
     ;(useSWR as jest.Mock).mockImplementation(() => ({ data: undefined }))
     const { result } = renderHook(() => useGetAccount())
     expect(result.current.data).toBe(undefined)
+    expect(result.current.found).toBe(false)
   })
 
-  test('success get property', async () => {
+  test('get profile', async () => {
     const data = [{ a: 'a' }]
     const error = undefined
     ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error }))
     const { result } = renderHook(() => useGetAccount('0x01234567890'))
     expect(result.current.data).toEqual({ a: 'a' })
+    expect(result.current.found).toBe(true)
+  })
+
+  test('get not registered profile', async () => {
+    const error = undefined
+    ;(useSWR as jest.Mock).mockImplementation(() => ({ data: [], error }))
+    const { result } = renderHook(() => useGetAccount('0x01234567890'))
+    expect(result.current.data).toEqual(undefined)
+    expect(result.current.found).toBe(true)
   })
 
   test('failure get profile', async () => {
@@ -28,5 +38,6 @@ describe('useGetAccount', () => {
     const { result } = renderHook(() => useGetAccount('0x01234567890'))
     expect(result.current.error).toBe(error)
     expect(result.current.error?.message).toBe(errorMessage)
+    expect(result.current.found).toBe(false)
   })
 })

--- a/packages/web/src/fixtures/dev-for-apps/functions/useGetAccount.ts
+++ b/packages/web/src/fixtures/dev-for-apps/functions/useGetAccount.ts
@@ -10,5 +10,7 @@ export const useGetAccount = (walletAddress?: string) => {
     () => whenDefined(walletAddress, x => getAccount(x)),
     { onError: err => message.error(err.message) }
   )
-  return { data: whenDefined(data, x => x[0]), error, mutate }
+  const found = data instanceof Array
+
+  return { data: whenDefined(data, x => x[0]), error, mutate, found }
 }

--- a/packages/web/src/pages/author/[authorAddress]/edit.tsx
+++ b/packages/web/src/pages/author/[authorAddress]/edit.tsx
@@ -35,16 +35,15 @@ const apiDataToUploadFile = ({ hash: uid, url, name, size, mime: type }: Image):
 })
 
 const ProfileUpdateForm = ({ accountAddress }: { accountAddress: string }) => {
-  const { data } = useGetAccount(accountAddress)
+  const { data, found } = useGetAccount(accountAddress)
   const { postAccountHandler: createAccount, isLoading } = useCreateAccount(accountAddress)
   const { putAccountHandler: updateAccount } = useUpdateAccount(Number(data?.id), accountAddress)
-  const isExists = Boolean(data)
   const handleSubmit = useCallback(
     (displayName: string, biography: string) => {
-      const handler = isExists ? updateAccount : createAccount
+      const handler = found ? updateAccount : createAccount
       handler(displayName, biography)
     },
-    [createAccount, updateAccount, isExists]
+    [createAccount, updateAccount, found]
   )
 
   return (
@@ -55,17 +54,13 @@ const ProfileUpdateForm = ({ accountAddress }: { accountAddress: string }) => {
       }
     >
       <Form.Item label="Dispaly Name" name="displayName">
-        {data === undefined ? (
-          <SkeletonInput />
-        ) : (
-          <Input placeholder="Enter the new display name" defaultValue={data.name} />
-        )}
+        {found ? <Input placeholder="Enter the new display name" defaultValue={data?.name} /> : <SkeletonInput />}
       </Form.Item>
       <Form.Item label="Biography" name="biography">
-        {data === undefined ? (
-          <SkeletonInput />
+        {found ? (
+          <Input.TextArea placeholder="Enter the biography" defaultValue={data?.biography} />
         ) : (
-          <Input.TextArea placeholder="Enter the biography" defaultValue={data.biography} />
+          <SkeletonInput />
         )}
       </Form.Item>
       <Button type="primary" htmlType="submit" loading={isLoading} disabled={isLoading}>

--- a/packages/web/src/pages/author/[authorAddress]/edit.tsx
+++ b/packages/web/src/pages/author/[authorAddress]/edit.tsx
@@ -21,6 +21,7 @@ import { useRouter } from 'next/router'
 import { useListOwnedPropertyMetaQuery } from '@dev/graphql'
 import { useProvider } from 'src/fixtures/wallet/hooks'
 import Link from 'next/link'
+import { FullpageWrap } from 'src/components/atoms/FullpageWrap'
 
 type InitialProps = {}
 type Props = {} & InitialProps
@@ -127,41 +128,43 @@ const AuthorEdit = (_: Props) => {
   const isAuthor = Boolean(data?.property_meta?.length) && accountAddress?.toLowerCase() === authorAddress.toLowerCase()
 
   return (
-    <>
-      <Header />
-      <EarlyAccess />
-      <Headline height={300}>
-        <h1>Profile settings</h1>
-      </Headline>
-      <Container>
-        {loading ? (
-          <Skeleton />
-        ) : isAuthor ? (
-          <>
-            <h2>Basic</h2>
-            <ProfileUpdateForm accountAddress={authorAddress} />
-            <Divider />
-            <h2>Avatar</h2>
-            <AvatarUpdateForm accountAddress={authorAddress} />
-            <Divider />
-            <h2>Cover Images</h2>
-            <CoverImagesUpdateForm accountAddress={authorAddress} />
-          </>
-        ) : (
-          <Result
-            status="error"
-            title="Not authorized"
-            subTitle="You do not have sufficient permission to edit this page."
-            extra={
-              <Link as={`/author/${authorAddress}`} href="/author/[authorAddress]">
-                <Button type="primary">Author Profile</Button>
-              </Link>
-            }
-          />
-        )}
-      </Container>
+    <FullpageWrap>
+      <main>
+        <Header />
+        <EarlyAccess />
+        <Headline height={300}>
+          <h1>Profile settings</h1>
+        </Headline>
+        <Container>
+          {loading ? (
+            <Skeleton />
+          ) : isAuthor ? (
+            <>
+              <h2>Basic</h2>
+              <ProfileUpdateForm accountAddress={authorAddress} />
+              <Divider />
+              <h2>Avatar</h2>
+              <AvatarUpdateForm accountAddress={authorAddress} />
+              <Divider />
+              <h2>Cover Images</h2>
+              <CoverImagesUpdateForm accountAddress={authorAddress} />
+            </>
+          ) : (
+            <Result
+              status="error"
+              title="Not authorized"
+              subTitle="You do not have sufficient permission to edit this page."
+              extra={
+                <Link as={`/author/${authorAddress}`} href="/author/[authorAddress]">
+                  <Button type="primary">Author Profile</Button>
+                </Link>
+              }
+            />
+          )}
+        </Container>
+      </main>
       <Footer />
-    </>
+    </FullpageWrap>
   )
 }
 

--- a/packages/web/src/pages/settings/profile.tsx
+++ b/packages/web/src/pages/settings/profile.tsx
@@ -1,0 +1,151 @@
+import React, { useCallback, useState } from 'react'
+import { Footer } from 'src/components/organisms/Footer'
+import { EarlyAccess } from 'src/components/atoms/EarlyAccess'
+import { Headline } from 'src/components/atoms/Headline'
+import { Header } from 'src/components/organisms/Header'
+import { Container } from 'src/components/atoms/Container'
+import { useProvider } from 'src/fixtures/wallet/hooks'
+import {
+  useCreateAccount,
+  useGetAccount,
+  useUpdateAccount,
+  useUploadAccountAvatar,
+  useUploadAccountCoverImages
+} from 'src/fixtures/dev-for-apps/hooks'
+import { Button, Divider, Form, Input, Upload } from 'antd'
+import { whenDefined } from 'src/fixtures/utility'
+import { NotConnectedAndEmpty } from 'src/components/atoms/NotConnectedAndEmpty'
+import { UploadChangeParam, UploadFile } from 'antd/lib/upload/interface'
+import { useEffect } from 'react'
+import { Image } from 'src/fixtures/dev-for-apps/utility'
+import SkeletonInput from 'antd/lib/skeleton/Input'
+
+type InitialProps = {}
+type Props = {} & InitialProps
+
+const apiDataToUploadFile = ({ hash: uid, url, name, size, mime: type }: Image): UploadFile => ({
+  status: 'done',
+  uid,
+  url,
+  name,
+  size,
+  type
+})
+
+const ProfileUpdateForm = ({ accountAddress }: { accountAddress: string }) => {
+  const { data } = useGetAccount(accountAddress)
+  const { postAccountHandler: createAccount, isLoading } = useCreateAccount(accountAddress)
+  const { putAccountHandler: updateAccount } = useUpdateAccount(Number(data?.id), accountAddress)
+  const isExists = Boolean(data)
+  const handleSubmit = useCallback(
+    (displayName: string, biography: string) => {
+      const handler = isExists ? updateAccount : createAccount
+      handler(displayName, biography)
+    },
+    [createAccount, updateAccount, isExists]
+  )
+
+  return (
+    <Form
+      layout="vertical"
+      onFinish={({ displayName, biography }: { displayName: string; biography: string }) =>
+        handleSubmit(displayName, biography)
+      }
+    >
+      <Form.Item label="Dispaly Name" name="displayName">
+        {data === undefined ? (
+          <SkeletonInput />
+        ) : (
+          <Input placeholder="Enter the new display name" defaultValue={data.name} />
+        )}
+      </Form.Item>
+      <Form.Item label="Biography" name="biography">
+        {data === undefined ? (
+          <SkeletonInput />
+        ) : (
+          <Input.TextArea placeholder="Enter the biography" defaultValue={data.biography} />
+        )}
+      </Form.Item>
+      <Button type="primary" htmlType="submit" loading={isLoading} disabled={isLoading}>
+        Save
+      </Button>
+    </Form>
+  )
+}
+
+const AvatarUpdateForm = ({ accountAddress }: { accountAddress: string }) => {
+  const { data } = useGetAccount(accountAddress)
+  const [fileList, setFileList] = useState<UploadFile[] | undefined>()
+  const { upload } = useUploadAccountAvatar(accountAddress)
+  useEffect(() => {
+    setFileList(whenDefined(data?.portrait, x => [apiDataToUploadFile(x)]))
+  }, [setFileList, data])
+
+  const handleChange = (info: UploadChangeParam<UploadFile>) => {
+    if (info.event) {
+      setFileList([{ ...info.file, status: 'uploading' }])
+      upload(info.file.originFileObj)
+    }
+  }
+
+  return (
+    <Upload name="portrait" multiple={false} listType="picture-card" fileList={fileList} onChange={handleChange}>
+      <div>
+        <p>{data && data.portrait ? 'Change' : 'Upload'}</p>
+      </div>
+    </Upload>
+  )
+}
+
+const CoverImagesUpdateForm = ({ accountAddress }: { accountAddress: string }) => {
+  const { data } = useGetAccount(accountAddress)
+  const [fileList, setFileList] = useState<UploadFile[] | undefined>()
+  const { upload } = useUploadAccountCoverImages(accountAddress)
+  useEffect(() => {
+    setFileList(whenDefined(data?.cover_images, x => x.map(y => apiDataToUploadFile(y))))
+  }, [setFileList, data])
+
+  const handleChange = (info: UploadChangeParam<UploadFile>) => {
+    if (info.event) {
+      setFileList([...(fileList ?? []), { ...info.file, status: 'uploading' }])
+      upload(info.file.originFileObj)
+    }
+  }
+
+  return (
+    <Upload name="portrait" multiple={false} listType="picture-card" fileList={fileList} onChange={handleChange}>
+      <div>
+        <p>Upload</p>
+      </div>
+    </Upload>
+  )
+}
+
+const ProfileSettings = (_: Props) => {
+  const { accountAddress } = useProvider()
+
+  return (
+    <>
+      <Header />
+      <EarlyAccess />
+      <Headline height={300}>
+        <h1>Profile settings</h1>
+      </Headline>
+      {whenDefined(accountAddress, account => (
+        <Container>
+          <h2>Basic</h2>
+          <ProfileUpdateForm accountAddress={account} />
+          <Divider />
+          <h2>Avatar</h2>
+          <AvatarUpdateForm accountAddress={account} />
+          <Divider />
+          <h2>Cover Images</h2>
+          <CoverImagesUpdateForm accountAddress={account} />
+        </Container>
+      )) ?? <NotConnectedAndEmpty />}
+      <Footer />
+    </>
+  )
+}
+
+export default ProfileSettings


### PR DESCRIPTION
## Proposed Changes

I implemented "/author/[authorAddress]/edit" page's contents.

## Implementation

### When the author himself accesses
![localhost_3000_author_0x7d41cE3E13082935b27b2CD110F8371638DcA555_edit](https://user-images.githubusercontent.com/1970283/100461114-a9e9b880-310b-11eb-830e-b2b9e656ed2b.png)

### When anyone other than the author accesses
![localhost_3000_author_0x7d41cE3E13082935b27b2CD110F8371638DcA556_edit](https://user-images.githubusercontent.com/1970283/100461130-ae15d600-310b-11eb-8498-92f33e896b09.png)

## Note

_`/settings/profile` page is no longer in use and should be removed. Then, the linked page of "Profile" in the global header disappears, so it is necessary to tweak it._