### PR TITLE
Improve access to dev for apps (strapi)

### DIFF
--- a/packages/web/src/fixtures/dev-for-apps/functions/useGetProperty.spec.ts
+++ b/packages/web/src/fixtures/dev-for-apps/functions/useGetProperty.spec.ts
@@ -1,0 +1,32 @@
+import useSWR from 'swr'
+import { renderHook } from '@testing-library/react-hooks'
+import { useGetProperty } from './useGetProperty'
+
+jest.mock('swr')
+jest.mock('src/fixtures/dev-for-apps/utility.ts')
+
+describe('useGetProperty', () => {
+  test('give undefined', async () => {
+    ;(useSWR as jest.Mock).mockImplementation(() => ({ data: undefined }))
+    const { result } = renderHook(() => useGetProperty())
+    expect(result.current.data).toBe(undefined)
+  })
+
+  test('success get property', async () => {
+    const data = [{ a: 'a' }]
+    const error = undefined
+    ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error }))
+    const { result } = renderHook(() => useGetProperty('0x01234567890'))
+    expect(result.current.data).toEqual({ a: 'a' })
+  })
+
+  test('failure get property', async () => {
+    const data = undefined
+    const errorMessage = 'error'
+    const error = new Error(errorMessage)
+    ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error }))
+    const { result } = renderHook(() => useGetProperty('0x01234567890'))
+    expect(result.current.error).toBe(error)
+    expect(result.current.error?.message).toBe(errorMessage)
+  })
+})

--- a/packages/web/src/fixtures/dev-for-apps/functions/useGetProperty.ts
+++ b/packages/web/src/fixtures/dev-for-apps/functions/useGetProperty.ts
@@ -12,5 +12,5 @@ export const useGetProperty = (propertyAddress?: string) => {
   )
   const found = data instanceof Array
 
-  return { data: data ? data[0] : data, error, mutate, found }
+  return { data: whenDefined(data, x => x[0]), error, mutate, found }
 }

--- a/packages/web/src/fixtures/dev-for-apps/hooks.spec.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.spec.ts
@@ -8,7 +8,6 @@ import {
   useCreateProperty,
   useUpdateProperty,
   useUploadAccountAvatar,
-  useUploadAccountCoverImages,
   useUploadPropertyCoverImages
 } from './hooks'
 import { postPropertyTags, postAccount, putAccount, postProperty, putProperty } from './utility'
@@ -111,45 +110,6 @@ describe('dev-for-apps hooks with strapi for account', () => {
         error
       }))
       const { result } = renderHook(() => useUploadAccountAvatar('0x01234567890'))
-      act(() => {
-        result.current.upload({})
-      })
-      expect(result.current.isLoading).toBe(false)
-      expect(result.current.error?.message).toBe(errorMessage)
-    })
-  })
-
-  describe('useUploadAccountCoverImages', () => {
-    test('success post file', async () => {
-      const mockHandler = jest.fn().mockImplementation(jest.fn().mockImplementation(() => Promise.resolve()))
-      const mockMutate = jest.fn().mockImplementation(() => {})
-      ;(useGetAccount as jest.Mock).mockImplementation(() => ({ data: { id: 123 }, mutate: mockMutate }))
-      ;(useUploadFile as jest.Mock).mockImplementation(() => ({
-        postUploadFileHandler: mockHandler,
-        isLoading: false
-      }))
-      const { result } = renderHook(() => useUploadAccountCoverImages('0x01234567890'))
-      await act(() => {
-        result.current.upload('image data')
-      })
-      expect(mockHandler.mock.calls[0][0]).toBe(123)
-      expect(mockHandler.mock.calls[0][1]).toBe('Account')
-      expect(mockHandler.mock.calls[0][2]).toBe('cover_images')
-      expect(mockHandler.mock.calls[0][3]).toBe('image data')
-      expect(mockHandler.mock.calls[0][4]).toBe('assets/0x01234567890/cover_images')
-      expect(mockMutate.mock.calls.length).toBe(1)
-    })
-
-    test('failure post file', async () => {
-      const errorMessage = 'error'
-      const error = new Error(errorMessage)
-      ;(useGetAccount as jest.Mock).mockImplementation(() => ({ data: { id: 123 }, mutate: () => {} }))
-      ;(useUploadFile as jest.Mock).mockImplementation(() => ({
-        postUploadFileHandler: () => Promise.resolve(),
-        isLoading: false,
-        error
-      }))
-      const { result } = renderHook(() => useUploadAccountCoverImages('0x01234567890'))
       act(() => {
         result.current.upload({})
       })

--- a/packages/web/src/fixtures/dev-for-apps/hooks.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.ts
@@ -249,23 +249,6 @@ export const useUpdateProperty = (id: number, walletAddress: string) => {
   return { putPropertyHandler, isLoading }
 }
 
-export const useUploadAccountCoverImages = (accountAddress: string) => {
-  const { data: account, mutate } = useGetAccount(accountAddress)
-  const { postUploadFileHandler, isLoading, error } = useUploadFile(accountAddress)
-
-  const upload = async (file: any) => {
-    const refId = Number(account?.id)
-    const ref = 'Account'
-    const field = 'cover_images'
-    const path = `assets/${accountAddress}/${field}`
-    return postUploadFileHandler(refId, ref, field, file, path).then(x => {
-      mutate()
-      return x
-    })
-  }
-  return { upload, isLoading, error }
-}
-
 export const useUploadPropertyCoverImages = (propertyAddress: string) => {
   const { data: property, mutate } = useGetProperty(propertyAddress)
   const { postUploadFileHandler, isLoading, error } = useUploadFile(propertyAddress)

--- a/packages/web/src/fixtures/dev-for-apps/hooks.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.ts
@@ -75,11 +75,6 @@ export const useCreateAccount = (walletAddress: string) => {
   const { web3 } = useProvider()
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
-  const shouldFetch = walletAddress !== ''
-  const { data, mutate } = useSWR<UnwrapFunc<typeof postAccount>, Error>(
-    shouldFetch ? SWRCachePath.createAccount() : null
-  )
-
   const postAccountHandler = async (name?: string, biography?: string, website?: string, github?: string) => {
     const links: ProfileLinks = {
       github,
@@ -94,34 +89,28 @@ export const useCreateAccount = (walletAddress: string) => {
     setIsLoading(true)
     message.loading({ content: 'update account data...', duration: 0, key })
 
-    await mutate(
-      postAccount(signedMessage, signature, walletAddress, name, biography, links)
-        .then(result => {
-          message.success({ content: 'success update account data', key })
-          return result
-        })
-        .catch(err => {
-          message.error({ content: err.message, key })
-          return Promise.reject(data)
-        }),
-      false
-    )
+    const data = await postAccount(signedMessage, signature, walletAddress, name, biography, links)
+      .then(result => {
+        message.success({ content: 'success update account data', key })
+        return result
+      })
+      .catch(err => {
+        message.error({ content: err.message, key })
+        return Promise.reject({})
+      })
 
     setIsLoading(false)
+
+    return data
   }
 
-  return { data, postAccountHandler, isLoading }
+  return { postAccountHandler, isLoading }
 }
 
 export const useUpdateAccount = (id: number, walletAddress: string) => {
   const key = 'useUpdateAccount'
   const { web3 } = useProvider()
   const [isLoading, setIsLoading] = useState<boolean>(false)
-
-  const shouldFetch = id !== 0
-  const { data, mutate } = useSWR<UnwrapFunc<typeof putAccount>, Error>(
-    shouldFetch ? SWRCachePath.updateAccount(id) : null
-  )
 
   const putAccountHandler = async (name?: string, biography?: string, website?: string, github?: string) => {
     const links: ProfileLinks = {
@@ -137,23 +126,22 @@ export const useUpdateAccount = (id: number, walletAddress: string) => {
     setIsLoading(true)
     message.loading({ content: 'update account data...', duration: 0, key })
 
-    await mutate(
-      putAccount(signedMessage, signature, walletAddress, id, name, biography, links)
-        .then(result => {
-          message.success({ content: 'success update account data', key })
-          return result
-        })
-        .catch(err => {
-          message.error({ content: err.message, key })
-          return Promise.reject(data)
-        }),
-      false
-    )
+    const data = await putAccount(signedMessage, signature, walletAddress, id, name, biography, links)
+      .then(result => {
+        message.success({ content: 'success update account data', key })
+        return result
+      })
+      .catch(err => {
+        message.error({ content: err.message, key })
+        return Promise.reject({})
+      })
 
     setIsLoading(false)
+
+    return data
   }
 
-  return { data, putAccountHandler, isLoading }
+  return { putAccountHandler, isLoading }
 }
 
 export const useUploadAccountAvatar = (accountAddress: string) => {
@@ -178,11 +166,6 @@ export const useCreateProperty = (walletAddress: string) => {
   const { web3 } = useProvider()
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
-  const shouldFetch = walletAddress !== ''
-  const { data, mutate } = useSWR<UnwrapFunc<typeof postProperty>, Error>(
-    shouldFetch ? SWRCachePath.createProperty() : null
-  )
-
   const postPropertyHandler = async (
     name?: string,
     description?: string,
@@ -204,34 +187,28 @@ export const useCreateProperty = (walletAddress: string) => {
     setIsLoading(true)
     message.loading({ content: 'update property data...', duration: 0, key })
 
-    await mutate(
-      postProperty(signedMessage, signature, walletAddress, name, description, links)
-        .then(result => {
-          message.success({ content: 'success update property data', key })
-          return result
-        })
-        .catch(err => {
-          message.error({ content: err.message, key })
-          return Promise.reject(data)
-        }),
-      false
-    )
+    const data = await postProperty(signedMessage, signature, walletAddress, name, description, links)
+      .then(result => {
+        message.success({ content: 'success update property data', key })
+        return result
+      })
+      .catch(err => {
+        message.error({ content: err.message, key })
+        return Promise.reject({})
+      })
 
     setIsLoading(false)
+
+    return data
   }
 
-  return { data, postPropertyHandler, isLoading }
+  return { postPropertyHandler, isLoading }
 }
 
 export const useUpdateProperty = (id: number, walletAddress: string) => {
   const key = 'useUpdateProperty'
   const { web3 } = useProvider()
   const [isLoading, setIsLoading] = useState<boolean>(false)
-
-  const shouldFetch = id !== 0
-  const { data, mutate } = useSWR<UnwrapFunc<typeof putProperty>, Error>(
-    shouldFetch ? SWRCachePath.updateProperty(id) : null
-  )
 
   const putPropertyHandler = async (
     name?: string,
@@ -254,23 +231,22 @@ export const useUpdateProperty = (id: number, walletAddress: string) => {
     setIsLoading(true)
     message.loading({ content: 'update property data...', duration: 0, key })
 
-    await mutate(
-      putProperty(signedMessage, signature, walletAddress, id, name, description, links)
-        .then(result => {
-          message.success({ content: 'success update property data', key })
-          return result
-        })
-        .catch(err => {
-          message.error({ content: err.message, key })
-          return Promise.reject(data)
-        }),
-      false
-    )
+    const data = await putProperty(signedMessage, signature, walletAddress, id, name, description, links)
+      .then(result => {
+        message.success({ content: 'success update property data', key })
+        return result
+      })
+      .catch(err => {
+        message.error({ content: err.message, key })
+        return Promise.reject({})
+      })
 
     setIsLoading(false)
+
+    return data
   }
 
-  return { data, putPropertyHandler, isLoading }
+  return { putPropertyHandler, isLoading }
 }
 
 export const useUploadAccountCoverImages = (accountAddress: string) => {

--- a/packages/web/src/fixtures/dev-for-apps/utility.ts
+++ b/packages/web/src/fixtures/dev-for-apps/utility.ts
@@ -22,7 +22,6 @@ export interface Account {
   biography: string
   portrait: Image
   links: NullableProfileLinks
-  cover_images: Image[]
 }
 
 export type ImageFormat = {

--- a/packages/web/src/pages/author/[authorAddress]/edit.tsx
+++ b/packages/web/src/pages/author/[authorAddress]/edit.tsx
@@ -41,10 +41,10 @@ const ProfileUpdateForm = ({ accountAddress }: { accountAddress: string }) => {
   const { putAccountHandler: updateAccount } = useUpdateAccount(Number(data?.id), accountAddress)
   const handleSubmit = useCallback(
     (displayName: string, biography: string, website: string, github: string) => {
-      const handler = found ? updateAccount : createAccount
+      const handler = data?.id ? updateAccount : createAccount
       handler(displayName, biography, website, github)
     },
-    [createAccount, updateAccount, found]
+    [createAccount, updateAccount, data]
   )
 
   return (

--- a/packages/web/src/pages/author/[authorAddress]/edit.tsx
+++ b/packages/web/src/pages/author/[authorAddress]/edit.tsx
@@ -8,8 +8,7 @@ import {
   useCreateAccount,
   useGetAccount,
   useUpdateAccount,
-  useUploadAccountAvatar,
-  useUploadAccountCoverImages
+  useUploadAccountAvatar
 } from 'src/fixtures/dev-for-apps/hooks'
 import { Button, Divider, Form, Input, Result, Skeleton, Upload } from 'antd'
 import { whenDefined } from 'src/fixtures/utility'
@@ -109,30 +108,6 @@ const AvatarUpdateForm = ({ accountAddress }: { accountAddress: string }) => {
   )
 }
 
-const CoverImagesUpdateForm = ({ accountAddress }: { accountAddress: string }) => {
-  const { data } = useGetAccount(accountAddress)
-  const [fileList, setFileList] = useState<UploadFile[] | undefined>()
-  const { upload } = useUploadAccountCoverImages(accountAddress)
-  useEffect(() => {
-    setFileList(whenDefined(data?.cover_images, x => x.map(y => apiDataToUploadFile(y))))
-  }, [setFileList, data])
-
-  const handleChange = (info: UploadChangeParam<UploadFile>) => {
-    if (info.event) {
-      setFileList([...(fileList ?? []), { ...info.file, status: 'uploading' }])
-      upload(info.file.originFileObj)
-    }
-  }
-
-  return (
-    <Upload name="portrait" multiple={false} listType="picture-card" fileList={fileList} onChange={handleChange}>
-      <div>
-        <p>Upload</p>
-      </div>
-    </Upload>
-  )
-}
-
 const AuthorEdit = (_: Props) => {
   const { accountAddress } = useProvider()
   const { authorAddress } = useRouter().query as { authorAddress: string }
@@ -159,9 +134,6 @@ const AuthorEdit = (_: Props) => {
               <Divider />
               <h2>Avatar</h2>
               <AvatarUpdateForm accountAddress={authorAddress} />
-              <Divider />
-              <h2>Cover Images</h2>
-              <CoverImagesUpdateForm accountAddress={authorAddress} />
             </>
           ) : (
             <Result


### PR DESCRIPTION
## Proposed Changes
* Remove `Account.cover_images` attribute (for #768)
* Avoid `GET` access with API for `POST` and `PUT` method (create/update account, create/update property)
  * ref: https://github.com/dev-protocol/stakes.social/pull/763#issuecomment-735844618
* Fixed an issue with PUT access when accessing the Account content type if the backend does not yet have data. 
* add some unit test for dev-for-apps fixtures