### PR TITLE
Improve access to dev for apps 2

### DIFF
--- a/packages/web/src/fixtures/dev-for-apps/functions/useGetProperty.spec.ts
+++ b/packages/web/src/fixtures/dev-for-apps/functions/useGetProperty.spec.ts
@@ -1,0 +1,32 @@
+import useSWR from 'swr'
+import { renderHook } from '@testing-library/react-hooks'
+import { useGetProperty } from './useGetProperty'
+
+jest.mock('swr')
+jest.mock('src/fixtures/dev-for-apps/utility.ts')
+
+describe('useGetProperty', () => {
+  test('give undefined', async () => {
+    ;(useSWR as jest.Mock).mockImplementation(() => ({ data: undefined }))
+    const { result } = renderHook(() => useGetProperty())
+    expect(result.current.data).toBe(undefined)
+  })
+
+  test('success get property', async () => {
+    const data = [{ a: 'a' }]
+    const error = undefined
+    ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error }))
+    const { result } = renderHook(() => useGetProperty('0x01234567890'))
+    expect(result.current.data).toEqual({ a: 'a' })
+  })
+
+  test('failure get property', async () => {
+    const data = undefined
+    const errorMessage = 'error'
+    const error = new Error(errorMessage)
+    ;(useSWR as jest.Mock).mockImplementation(() => ({ data, error }))
+    const { result } = renderHook(() => useGetProperty('0x01234567890'))
+    expect(result.current.error).toBe(error)
+    expect(result.current.error?.message).toBe(errorMessage)
+  })
+})

--- a/packages/web/src/fixtures/dev-for-apps/functions/useGetProperty.ts
+++ b/packages/web/src/fixtures/dev-for-apps/functions/useGetProperty.ts
@@ -12,5 +12,5 @@ export const useGetProperty = (propertyAddress?: string) => {
   )
   const found = data instanceof Array
 
-  return { data: data ? data[0] : data, error, mutate, found }
+  return { data: whenDefined(data, x => x[0]), error, mutate, found }
 }

--- a/packages/web/src/fixtures/dev-for-apps/hooks.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.ts
@@ -75,11 +75,6 @@ export const useCreateAccount = (walletAddress: string) => {
   const { web3 } = useProvider()
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
-  const shouldFetch = walletAddress !== ''
-  const { data, mutate } = useSWR<UnwrapFunc<typeof postAccount>, Error>(
-    shouldFetch ? SWRCachePath.createAccount() : null
-  )
-
   const postAccountHandler = async (name?: string, biography?: string, website?: string, github?: string) => {
     const links: ProfileLinks = {
       github,
@@ -94,34 +89,28 @@ export const useCreateAccount = (walletAddress: string) => {
     setIsLoading(true)
     message.loading({ content: 'update account data...', duration: 0, key })
 
-    await mutate(
-      postAccount(signedMessage, signature, walletAddress, name, biography, links)
-        .then(result => {
-          message.success({ content: 'success update account data', key })
-          return result
-        })
-        .catch(err => {
-          message.error({ content: err.message, key })
-          return Promise.reject(data)
-        }),
-      false
-    )
+    const data = await postAccount(signedMessage, signature, walletAddress, name, biography, links)
+      .then(result => {
+        message.success({ content: 'success update account data', key })
+        return result
+      })
+      .catch(err => {
+        message.error({ content: err.message, key })
+        return Promise.reject({})
+      })
 
     setIsLoading(false)
+
+    return data
   }
 
-  return { data, postAccountHandler, isLoading }
+  return { postAccountHandler, isLoading }
 }
 
 export const useUpdateAccount = (id: number, walletAddress: string) => {
   const key = 'useUpdateAccount'
   const { web3 } = useProvider()
   const [isLoading, setIsLoading] = useState<boolean>(false)
-
-  const shouldFetch = id !== 0
-  const { data, mutate } = useSWR<UnwrapFunc<typeof putAccount>, Error>(
-    shouldFetch ? SWRCachePath.updateAccount(id) : null
-  )
 
   const putAccountHandler = async (name?: string, biography?: string, website?: string, github?: string) => {
     const links: ProfileLinks = {
@@ -137,23 +126,22 @@ export const useUpdateAccount = (id: number, walletAddress: string) => {
     setIsLoading(true)
     message.loading({ content: 'update account data...', duration: 0, key })
 
-    await mutate(
-      putAccount(signedMessage, signature, walletAddress, id, name, biography, links)
-        .then(result => {
-          message.success({ content: 'success update account data', key })
-          return result
-        })
-        .catch(err => {
-          message.error({ content: err.message, key })
-          return Promise.reject(data)
-        }),
-      false
-    )
+    const data = await putAccount(signedMessage, signature, walletAddress, id, name, biography, links)
+      .then(result => {
+        message.success({ content: 'success update account data', key })
+        return result
+      })
+      .catch(err => {
+        message.error({ content: err.message, key })
+        return Promise.reject({})
+      })
 
     setIsLoading(false)
+
+    return data
   }
 
-  return { data, putAccountHandler, isLoading }
+  return { putAccountHandler, isLoading }
 }
 
 export const useUploadAccountAvatar = (accountAddress: string) => {
@@ -178,11 +166,6 @@ export const useCreateProperty = (walletAddress: string) => {
   const { web3 } = useProvider()
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
-  const shouldFetch = walletAddress !== ''
-  const { data, mutate } = useSWR<UnwrapFunc<typeof postProperty>, Error>(
-    shouldFetch ? SWRCachePath.createProperty() : null
-  )
-
   const postPropertyHandler = async (
     name?: string,
     description?: string,
@@ -204,34 +187,28 @@ export const useCreateProperty = (walletAddress: string) => {
     setIsLoading(true)
     message.loading({ content: 'update property data...', duration: 0, key })
 
-    await mutate(
-      postProperty(signedMessage, signature, walletAddress, name, description, links)
-        .then(result => {
-          message.success({ content: 'success update property data', key })
-          return result
-        })
-        .catch(err => {
-          message.error({ content: err.message, key })
-          return Promise.reject(data)
-        }),
-      false
-    )
+    const data = await postProperty(signedMessage, signature, walletAddress, name, description, links)
+      .then(result => {
+        message.success({ content: 'success update property data', key })
+        return result
+      })
+      .catch(err => {
+        message.error({ content: err.message, key })
+        return Promise.reject({})
+      })
 
     setIsLoading(false)
+
+    return data
   }
 
-  return { data, postPropertyHandler, isLoading }
+  return { postPropertyHandler, isLoading }
 }
 
 export const useUpdateProperty = (id: number, walletAddress: string) => {
   const key = 'useUpdateProperty'
   const { web3 } = useProvider()
   const [isLoading, setIsLoading] = useState<boolean>(false)
-
-  const shouldFetch = id !== 0
-  const { data, mutate } = useSWR<UnwrapFunc<typeof putProperty>, Error>(
-    shouldFetch ? SWRCachePath.updateProperty(id) : null
-  )
 
   const putPropertyHandler = async (
     name?: string,
@@ -254,23 +231,22 @@ export const useUpdateProperty = (id: number, walletAddress: string) => {
     setIsLoading(true)
     message.loading({ content: 'update property data...', duration: 0, key })
 
-    await mutate(
-      putProperty(signedMessage, signature, walletAddress, id, name, description, links)
-        .then(result => {
-          message.success({ content: 'success update property data', key })
-          return result
-        })
-        .catch(err => {
-          message.error({ content: err.message, key })
-          return Promise.reject(data)
-        }),
-      false
-    )
+    const data = await putProperty(signedMessage, signature, walletAddress, id, name, description, links)
+      .then(result => {
+        message.success({ content: 'success update property data', key })
+        return result
+      })
+      .catch(err => {
+        message.error({ content: err.message, key })
+        return Promise.reject({})
+      })
 
     setIsLoading(false)
+
+    return data
   }
 
-  return { data, putPropertyHandler, isLoading }
+  return { putPropertyHandler, isLoading }
 }
 
 export const useUploadAccountCoverImages = (accountAddress: string) => {

--- a/packages/web/src/pages/author/[authorAddress]/edit.tsx
+++ b/packages/web/src/pages/author/[authorAddress]/edit.tsx
@@ -41,10 +41,10 @@ const ProfileUpdateForm = ({ accountAddress }: { accountAddress: string }) => {
   const { putAccountHandler: updateAccount } = useUpdateAccount(Number(data?.id), accountAddress)
   const handleSubmit = useCallback(
     (displayName: string, biography: string, website: string, github: string) => {
-      const handler = found ? updateAccount : createAccount
+      const handler = data?.id ? updateAccount : createAccount
       handler(displayName, biography, website, github)
     },
-    [createAccount, updateAccount, found]
+    [createAccount, updateAccount, data]
   )
 
   return (


### PR DESCRIPTION
re-create for #771 

## Proposed Changes
* Avoid `GET` access with API for `POST` and `PUT` method (create/update account, create/update property)
  * ref: https://github.com/dev-protocol/stakes.social/pull/763#issuecomment-735844618
* Fixed an issue with PUT access when accessing the Account content type if the backend does not yet have data. 
* add some unit test for dev-for-apps fixtures
