### PR TITLE
fix: automatically reconnect when only is authorized client

### DIFF
--- a/packages/web/src/components/molecules/Navigation/index.tsx
+++ b/packages/web/src/components/molecules/Navigation/index.tsx
@@ -1,12 +1,11 @@
-import React, { Fragment } from 'react'
-import { useContext, useState } from 'react'
+import React from 'react'
+import { useState } from 'react'
 import { useCallback } from 'react'
 import { MenuInfo } from 'rc-menu/lib/interface'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import Hamburger from 'src/components/atoms/Svgs/tsx/Hamburger'
 import { NavMenu, NavMenuItem } from './../../atoms/Navigation/index'
-import WalletContext from 'src/context/walletContext'
 import { useEffectAsync } from 'src/fixtures/utility'
 
 interface NavigationProps {
@@ -48,23 +47,18 @@ export const Navigation = ({ handleMenuOpen }: NavigationProps) => {
   const router = useRouter()
   const [current, setCurrent] = useState(toKey(router?.pathname) || Navigations[0].key)
   const [isDesktop, setDesktop] = useState(typeof window !== 'undefined' && window?.innerWidth > 1400)
-  const { web3Modal } = useContext(WalletContext)
 
   const updateMedia = () => {
     setDesktop(window.innerWidth > 1400)
   }
 
   useEffectAsync(async () => {
-    if (web3Modal?.cachedProvider) {
-      await web3Modal.connect()
-    }
-
     if (typeof window !== 'undefined') {
       window.addEventListener('resize', updateMedia)
       return () => window.removeEventListener('resize', updateMedia)
     }
     return setDesktop(true)
-  }, [web3Modal])
+  }, [])
 
   const handleClick = useCallback(
     (e: MenuInfo) => {

--- a/packages/web/src/pages/_app.tsx
+++ b/packages/web/src/pages/_app.tsx
@@ -13,6 +13,7 @@ import WalletConnectProvider from '@walletconnect/web3-provider'
 import Fortmatic from 'fortmatic'
 import WalletLink from 'walletlink'
 import { WEB3_PROVIDER_ENDPOINT } from 'src/fixtures/wallet/constants'
+import { getAccountAddress } from 'src/fixtures/wallet/utility'
 
 class NextApp extends App<AppInitialProps & WithApolloProps<{}>> {
   state = { isCurrencyDEV: true, web3: undefined, web3Modal: undefined }
@@ -65,6 +66,14 @@ class NextApp extends App<AppInitialProps & WithApolloProps<{}>> {
   web3Modal: any
 
   onWalletConnet = async () => {
+    const web3ForInjected: any = await detectEthereumProvider()
+    if (!web3ForInjected) {
+      return
+    }
+    const isAuthorized = await getAccountAddress(new Web3(web3ForInjected))
+    if (!isAuthorized) {
+      return
+    }
     const provider = await this.web3Modal.connect().catch(() => {
       return undefined
     })
@@ -89,7 +98,7 @@ class NextApp extends App<AppInitialProps & WithApolloProps<{}>> {
     })
     this.setState({ web3Modal: this.web3Modal })
 
-    if (this.web3Modal.cachedProvider) {
+    if (this.web3Modal.cachedProvider === 'injected') {
       this.onWalletConnet()
     }
 


### PR DESCRIPTION
## Proposed Changes
for #776 

Behavior before change:
```
(wallet state: disconnect) -> connect on stakes.social site -> (state: connected)
  -> reload browser -> (state: connected)
    -> disconnect on metamask dialog -> reload (state: disconnect) -> displayed wallet connect dialog
```

Behavior after change:
```
(wallet state: disconnect) -> connect on stakes.social site -> (state: connected)
  -> reload browser -> (state: connected)
    -> disconnect on metamask dialog -> reload (state: disconnect) -> not displayed wallet connect dialog
```

## Implementation
