### PR TITLE
Fix routing errors on static built Next.js

### DIFF
--- a/packages/web/src/fixtures/utility/route.ts
+++ b/packages/web/src/fixtures/utility/route.ts
@@ -1,0 +1,2 @@
+export const getPath = (pathName: string): string[] =>
+  (pathName.startsWith('/') ? pathName.replace(/^\//, '') : pathName).split('/')

--- a/packages/web/src/pages/[propertyAddress].tsx
+++ b/packages/web/src/pages/[propertyAddress].tsx
@@ -23,6 +23,7 @@ import { Avatar } from 'src/components/molecules/Avatar'
 import { CoverImageOrGradient } from 'src/components/atoms/CoverImageOrGradient'
 import { H3 } from 'src/components/atoms/Typography'
 import { Twitter, Github } from 'src/components/atoms/SocialButtons'
+import { getPath } from 'src/fixtures/utility/route'
 
 type Props = {}
 
@@ -187,7 +188,7 @@ const Author = ({ propertyAddress }: { propertyAddress: string }) => {
 }
 
 const PropertyAddressDetail = (_: Props) => {
-  const { propertyAddress } = useRouter().query as { propertyAddress: string }
+  const [propertyAddress] = getPath(useRouter().asPath)
   const { apy, creators } = useAPY()
   const { data } = useGetPropertyAuthenticationQuery({ variables: { propertyAddress } })
   const { data: dataProperty } = useGetProperty(propertyAddress)

--- a/packages/web/src/pages/author/[authorAddress].tsx
+++ b/packages/web/src/pages/author/[authorAddress].tsx
@@ -25,6 +25,7 @@ import { useProvider } from 'src/fixtures/wallet/hooks'
 import { useState } from 'react'
 import { useCurrency } from 'src/fixtures/currency/hooks'
 import { Pagination, Spin } from 'antd'
+import { getPath } from 'src/fixtures/utility/route'
 
 type Props = {}
 
@@ -298,8 +299,7 @@ const Section = styled.a<{ activeSection: string; section: string }>`
 `
 
 const AuthorAddressDetail = (_: Props) => {
-  const router = useRouter()
-  let { authorAddress } = router.query
+  const [, authorAddress] = getPath(useRouter().asPath)
   const author: string = typeof authorAddress == 'string' ? authorAddress : 'none'
   const { data: authorInformation } = useGetAuthorInformation(author)
   const [paginationProps, setPaginationProps] = useState<{ offset: number; limit: number; currentPage: number }>({

--- a/packages/web/src/pages/author/[authorAddress]/edit.tsx
+++ b/packages/web/src/pages/author/[authorAddress]/edit.tsx
@@ -22,6 +22,7 @@ import { useListOwnedPropertyMetaQuery } from '@dev/graphql'
 import { useProvider } from 'src/fixtures/wallet/hooks'
 import Link from 'next/link'
 import { FullpageWrap } from 'src/components/atoms/FullpageWrap'
+import { getPath } from 'src/fixtures/utility/route'
 
 type InitialProps = {}
 type Props = {} & InitialProps
@@ -135,7 +136,7 @@ const CoverImagesUpdateForm = ({ accountAddress }: { accountAddress: string }) =
 
 const AuthorEdit = (_: Props) => {
   const { accountAddress } = useProvider()
-  const { authorAddress } = useRouter().query as { authorAddress: string }
+  const [, authorAddress] = getPath(useRouter().asPath)
   const { data, loading } = useListOwnedPropertyMetaQuery({
     variables: { account_address: authorAddress, offset: 0, limit: 1 }
   })

--- a/packages/web/src/pages/create/[market]/index.tsx
+++ b/packages/web/src/pages/create/[market]/index.tsx
@@ -6,6 +6,7 @@ import { Header } from 'src/components/organisms/Header'
 import { Headline } from 'src/components/atoms/Headline'
 import { H2 } from 'src/components/atoms/Typography'
 import styled from 'styled-components'
+import { getPath } from 'src/fixtures/utility/route'
 
 type Props = {}
 
@@ -28,7 +29,7 @@ const ResponsiveContainer = styled(Container)`
 `
 
 const AuthenticateNewAsset = (_: Props) => {
-  const { market } = useRouter().query as { market: string }
+  const [, market] = getPath(useRouter().asPath)
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>

--- a/packages/web/src/pages/create/associate/[market]/index.tsx
+++ b/packages/web/src/pages/create/associate/[market]/index.tsx
@@ -6,6 +6,7 @@ import { Header } from 'src/components/organisms/Header'
 import { Headline } from 'src/components/atoms/Headline'
 import { H2 } from 'src/components/atoms/Typography'
 import styled from 'styled-components'
+import { getPath } from 'src/fixtures/utility/route'
 
 type Props = {}
 
@@ -34,7 +35,7 @@ const ResponsiveContainer = styled(Container)`
 `
 
 const AuthenticateNewAsset = (_: Props) => {
-  const { market, property } = useRouter().query as { market: string; property: string }
+  const [, , market, property] = getPath(useRouter().asPath)
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>

--- a/packages/web/src/pages/invite/[market]/index.tsx
+++ b/packages/web/src/pages/invite/[market]/index.tsx
@@ -6,6 +6,7 @@ import { Header } from 'src/components/organisms/Header'
 import { Headline } from 'src/components/atoms/Headline'
 import { H2 } from 'src/components/atoms/Typography'
 import styled from 'styled-components'
+import { getPath } from 'src/fixtures/utility/route'
 
 type Props = {}
 
@@ -17,7 +18,7 @@ const WrapContainer = styled.div`
 `
 
 const InvitationRequest = (_: Props) => {
-  const { market } = useRouter().query as { market: string }
+  const [, market] = getPath(useRouter().asPath)
 
   return (
     <>


### PR DESCRIPTION
## Proposed Changes

`useRouter().query` does not work when the first loading, so `useRouter().asPath` I used.