### PR TITLE
Display 404 with not found property

### DIFF
--- a/packages/web/src/fixtures/devprtcl/cache-path.ts
+++ b/packages/web/src/fixtures/devprtcl/cache-path.ts
@@ -1,4 +1,4 @@
 export const SWRCachePath = {
-  getPropertyInformation: (propertyAddress: string) => `https://api.devprtcl.com/v1/property/${propertyAddress}`,
+  getPropertyInformation: (propertyAddress?: string) => `https://api.devprtcl.com/v1/property/${propertyAddress}`,
   getAuthorInformation: (authorAddress?: string) => `https://api.devprtcl.com/v1/author/${authorAddress}`
 } as const

--- a/packages/web/src/fixtures/devprtcl/hooks.ts
+++ b/packages/web/src/fixtures/devprtcl/hooks.ts
@@ -20,10 +20,10 @@ export const getPropertytInformation = (propertyAddress: string): Promise<Proper
 export const getAuthorInformation = (authorAddress: string): Promise<AuthorInformation> =>
   fetch(`https://api.devprtcl.com/v1/author/${authorAddress}`).then(res => res.json())
 
-export const useGetPropertytInformation = (propertyAddress: string) => {
-  const { data, error } = useSWR<UnwrapFunc<typeof getPropertytInformation>, Error>(
+export const useGetPropertytInformation = (propertyAddress?: string) => {
+  const { data, error } = useSWR<UnwrapFunc<typeof getPropertytInformation> | undefined, Error>(
     SWRCachePath.getPropertyInformation(propertyAddress),
-    () => getPropertytInformation(propertyAddress),
+    () => whenDefined(propertyAddress, address => getPropertytInformation(address)),
     { onError: err => message.error(err.message) }
   )
   return { data, error }

--- a/packages/web/src/pages/[propertyAddress].tsx
+++ b/packages/web/src/pages/[propertyAddress].tsx
@@ -192,7 +192,7 @@ const PropertyAddressDetail = (_: Props) => {
   const [propertyAddress] = getPath(useRouter().asPath)
   const { apy, creators } = useAPY()
   const { data } = useGetPropertyAuthenticationQuery({ variables: { propertyAddress } })
-  const isExistProperty = useMemo(() => data?.property_authentication.length > 0, [data])
+  const isExistProperty = useMemo(() => data && data?.property_authentication.length > 0, [data])
   const { data: dataProperty } = useGetProperty(isExistProperty ? propertyAddress : undefined)
   const { data: propertyInformation } = useGetPropertytInformation(isExistProperty ? propertyAddress : undefined)
   /* eslint-disable react-hooks/exhaustive-deps */

--- a/packages/web/src/pages/[propertyAddress].tsx
+++ b/packages/web/src/pages/[propertyAddress].tsx
@@ -200,11 +200,10 @@ const PropertyAddressDetail = (_: Props) => {
   const includedAssetList = useMemo(() => data?.property_authentication.map(e => e.authentication_id), [data])
   const { accountAddress: loggedInWallet } = useProvider()
 
-  if (data && !isExistProperty) {
-    return <Error statusCode={404} />
-  }
-
-  return (
+  return data && !isExistProperty ? (
+    // property is not found
+    <Error statusCode={404} />
+  ) : (
     <>
       <Header></Header>
       <Wrap>

--- a/packages/web/src/pages/[propertyAddress].tsx
+++ b/packages/web/src/pages/[propertyAddress].tsx
@@ -192,16 +192,15 @@ const PropertyAddressDetail = (_: Props) => {
   const [propertyAddress] = getPath(useRouter().asPath)
   const { apy, creators } = useAPY()
   const { data } = useGetPropertyAuthenticationQuery({ variables: { propertyAddress } })
-  const { data: dataProperty } = useGetProperty(data?.property_authentication.length > 0 ? propertyAddress : undefined)
-  const { data: propertyInformation } = useGetPropertytInformation(
-    data?.property_authentication.length > 0 ? propertyAddress : undefined
-  )
+  const isExistProperty = useMemo(() => data?.property_authentication.length > 0, [data])
+  const { data: dataProperty } = useGetProperty(isExistProperty ? propertyAddress : undefined)
+  const { data: propertyInformation } = useGetPropertytInformation(isExistProperty ? propertyAddress : undefined)
   /* eslint-disable react-hooks/exhaustive-deps */
   // FYI: https://github.com/facebook/react/pull/19062
   const includedAssetList = useMemo(() => data?.property_authentication.map(e => e.authentication_id), [data])
   const { accountAddress: loggedInWallet } = useProvider()
 
-  if (!data || data?.property_authentication.length <= 0) {
+  if (data && !isExistProperty) {
     return <Error statusCode={404} />
   }
 
@@ -214,10 +213,10 @@ const PropertyAddressDetail = (_: Props) => {
         </Container>
         <Main>
           <RoundedCoverImageOrGradient src={dataProperty?.cover_image?.url} ratio={52.5} />
-          <Possession propertyAddress={propertyAddress} />
+          {isExistProperty && <Possession propertyAddress={propertyAddress} />}
           <Transact>
-            <Stake title="Stake" propertyAddress={propertyAddress} />
-            <Withdraw title="Withdraw" propertyAddress={propertyAddress} />
+            {isExistProperty && <Stake title="Stake" propertyAddress={propertyAddress} />}
+            {isExistProperty && <Withdraw title="Withdraw" propertyAddress={propertyAddress} />}
           </Transact>
           <AboutSection>
             <h2>About</h2>
@@ -258,10 +257,10 @@ const PropertyAddressDetail = (_: Props) => {
               )}
             </AssetList>
           </AssetsSection>
-          <Author propertyAddress={propertyAddress} />
+          {isExistProperty && <Author propertyAddress={propertyAddress} />}
           <div>
             <h2>Top stakers</h2>
-            <TopStakerList propertyAdress={propertyAddress} />
+            {isExistProperty && <TopStakerList propertyAdress={propertyAddress} />}
           </div>
         </Main>
       </Wrap>

--- a/packages/web/src/pages/[propertyAddress].tsx
+++ b/packages/web/src/pages/[propertyAddress].tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useEffect } from 'react'
+import Error from 'next/error'
 import { useRouter } from 'next/router'
 import { PossessionOutline } from 'src/components/organisms/PossessionOutline'
 import { PropertyHeader } from 'src/components/organisms/PropertyHeader'
@@ -190,12 +191,18 @@ const PropertyAddressDetail = (_: Props) => {
   const { propertyAddress } = useRouter().query as { propertyAddress: string }
   const { apy, creators } = useAPY()
   const { data } = useGetPropertyAuthenticationQuery({ variables: { propertyAddress } })
-  const { data: dataProperty } = useGetProperty(propertyAddress)
-  const { data: propertyInformation } = useGetPropertytInformation(propertyAddress)
+  const { data: dataProperty } = useGetProperty(data?.property_authentication.length > 0 ? propertyAddress : undefined)
+  const { data: propertyInformation } = useGetPropertytInformation(
+    data?.property_authentication.length > 0 ? propertyAddress : undefined
+  )
   /* eslint-disable react-hooks/exhaustive-deps */
   // FYI: https://github.com/facebook/react/pull/19062
   const includedAssetList = useMemo(() => data?.property_authentication.map(e => e.authentication_id), [data])
   const { accountAddress: loggedInWallet } = useProvider()
+
+  if (!data || data?.property_authentication.length <= 0) {
+    return <Error statusCode={404} />
+  }
 
   return (
     <>


### PR DESCRIPTION
## Proposed Changes
If a non-existent property address is passed as an argument on the property page, page 404 will be displayed.
At that time, useless access to GraphQL, RestAPI and other backends is suppressed.

## Implementation
