### PR TITLE
change logo and fix wording for walletlink

### DIFF
--- a/packages/web/src/pages/_app.tsx
+++ b/packages/web/src/pages/_app.tsx
@@ -48,9 +48,8 @@ class NextApp extends App<AppInitialProps & WithApolloProps<{}>> {
       },
       'custom-walletlink': {
         display: {
-          logo:
-            'https://github.com/dev-protocol/asset.stakes.social/blob/main/public/wallet/coinbase-wallet.jpg?raw=true',
-          name: 'Wallet Link',
+          logo: 'https://github.com/dev-protocol/asset.stakes.social/blob/main/public/wallet/walletlink.jpg?raw=true',
+          name: 'WalletLink',
           description: 'Scan with WalletLink to connect'
         },
         package: walletLinkProvider,


### PR DESCRIPTION
## Proposed Changes
Scott's feedback.

* `Wallet Link` -> `WalletLink`
* update WalletLink Logo image

<img width="586" alt="walletlink" src="https://user-images.githubusercontent.com/150309/101297891-8e4e8280-386e-11eb-83d4-987ddb4d3258.png">

If the test passes, self-merge.

## Implementation
