### PR TITLE
Fix exception on liquidity page

### DIFF
--- a/packages/web/src/components/_pages/liquidity/Deposit/index.tsx
+++ b/packages/web/src/components/_pages/liquidity/Deposit/index.tsx
@@ -71,9 +71,6 @@ export const Deposit = () => {
   }, [totalStakingShares, totalStaked, accounting, finalUnlockSchedule])
   const updateEstimate = useCallback(
     (value?: BigNumber) => {
-      if (!web3) {
-        return
-      }
       const data = isFulfilled()
       if (data === false) {
         return setRequireReEstimate(true)
@@ -87,7 +84,7 @@ export const Deposit = () => {
       })
       setEstimatedReward(toNaturalNumber(estimated).dp(10).toFixed())
     },
-    [web3, estimate, isFulfilled]
+    [estimate, isFulfilled]
   )
   const updateAmount = useCallback(
     (value: string) => {
@@ -152,7 +149,7 @@ export const Deposit = () => {
     updateAmount('0')
     purge()
   }
-  if (requireReEstimate) {
+  if (requireReEstimate && web3) {
     updateEstimate(amount)
   }
 

--- a/packages/web/src/components/_pages/liquidity/Withdraw/index.tsx
+++ b/packages/web/src/components/_pages/liquidity/Withdraw/index.tsx
@@ -44,7 +44,6 @@ export const Withdraw = () => {
         whenDefined(web3, w =>
           unstakeQuery(w, queryAmount).then(x => {
             if (x) {
-              console.log(x.toFixed())
               setRewardClaimed(toNaturalNumber(x).toFixed())
             }
           })

--- a/packages/web/src/fixtures/_pages/liquidity/geyser/hooks.ts
+++ b/packages/web/src/fixtures/_pages/liquidity/geyser/hooks.ts
@@ -45,7 +45,6 @@ const getAllTokensClaimed = (client: Web3) => () =>
 
 const getTokensLocked = (client: Web3) => () =>
   allTokensLocked(client).then(allEvents => {
-    console.log(allEvents)
     return allEvents.reduce((a: BigNumber, c) => a.plus(c.returnValues.amount), toBigNumber(0))
   })
 

--- a/packages/web/src/fixtures/_pages/liquidity/geyser/hooks.ts
+++ b/packages/web/src/fixtures/_pages/liquidity/geyser/hooks.ts
@@ -37,7 +37,6 @@ import { useTheGraph } from '../uniswap-pool/hooks'
 
 const getAllTokensClaimed = (client: Web3) => () =>
   allTokensClaimed(client).then(allEvents => {
-    console.log(allEvents)
     return allEvents.reduce(
       (a: BigNumber, c) => a.plus(c.returnValues.amount),
       toBigNumber(allEvents[0]?.returnValues.amount || 0)


### PR DESCRIPTION
## Proposed Changes
for #858 

The following error occurs:
```
_app.tsx?2c35:43 Uncaught Error: Too many re-renders. React limits the number of renders to prevent an infinite loop.
    at renderWithHooks (react-dom.development.js?dc40:14815)
    at updateFunctionComponent (react-dom.development.js?dc40:17034)
    at beginWork (react-dom.development.js?dc40:18610)
    at HTMLUnknownElement.callCallback (react-dom.development.js?dc40:188)
    at Object.invokeGuardedCallbackDev (react-dom.development.js?dc40:237)
    at invokeGuardedCallback (react-dom.development.js?dc40:292)
    at beginWork$1 (react-dom.development.js?dc40:23203)
    at performUnitOfWork (react-dom.development.js?dc40:22154)
    at workLoopSync (react-dom.development.js?dc40:22130)
    at performSyncWorkOnRoot (react-dom.development.js?dc40:21756)
    at eval (react-dom.development.js?dc40:11089)
    at unstable_runWithPriority (scheduler.development.js?3552:653)
    at runWithPriority$1 (react-dom.development.js?dc40:11039)
    at flushSyncCallbackQueueImpl (react-dom.development.js?dc40:11084)
    at flushSyncCallbackQueue (react-dom.development.js?dc40:11072)
    at flushPendingDiscreteUpdates (react-dom.development.js?dc40:21847)
    at flushDiscreteUpdates (react-dom.development.js?dc40:21827)
    at finishEventHandler (react-dom.development.js?dc40:764)
    at batchedEventUpdates (react-dom.development.js?dc40:798)
    at dispatchEventForLegacyPluginEventSystem (react-dom.development.js?dc40:3568)
    at attemptToDispatchEvent (react-dom.development.js?dc40:4267)
    at dispatchEvent (react-dom.development.js?dc40:4189)
    at unstable_runWithPriority (scheduler.development.js?3552:653)
    at runWithPriority$1 (react-dom.development.js?dc40:11039)
    at discreteUpdates$1 (react-dom.development.js?dc40:21887)
    at discreteUpdates (react-dom.development.js?dc40:806)
    at dispatchDiscreteEvent (react-dom.development.js?dc40:4168)
```

## Implementation
* Added guard processing that check `web3` object is not null
* Changed to show a warning message when the deposit max or approve button is clicked when the user is not signed in
