### PR TITLE
Improve error message

### DIFF
--- a/packages/web/src/fixtures/devprtcl/hooks.ts
+++ b/packages/web/src/fixtures/devprtcl/hooks.ts
@@ -4,6 +4,8 @@ import { message } from 'antd'
 import { UnwrapFunc } from '../utility'
 import { whenDefined } from '../utility/logic'
 
+const messageKey = 'devprtclxyzRESTAccess'
+
 export interface PropertyInformation {
   name: string
   author: { karma: number; address: string }
@@ -24,7 +26,7 @@ export const useGetPropertytInformation = (propertyAddress?: string) => {
   const { data, error } = useSWR<UnwrapFunc<typeof getPropertytInformation> | undefined, Error>(
     SWRCachePath.getPropertyInformation(propertyAddress),
     () => whenDefined(propertyAddress, address => getPropertytInformation(address)),
-    { onError: err => message.error(err.message) }
+    { onError: err => message.error({ content: err.message, key: messageKey }) }
   )
   return { data, error }
 }
@@ -33,7 +35,7 @@ export const useGetAuthorInformation = (authorAddress?: string) => {
   const { data, error } = useSWR<UnwrapFunc<typeof getAuthorInformation> | undefined, Error>(
     SWRCachePath.getAuthorInformation(authorAddress),
     () => whenDefined(authorAddress, address => getAuthorInformation(address)),
-    { onError: err => message.error(err.message) }
+    { onError: err => message.error({ content: err.message, key: messageKey }) }
   )
   return { data, error }
 }

--- a/packages/web/src/fixtures/uniswap/hooks.ts
+++ b/packages/web/src/fixtures/uniswap/hooks.ts
@@ -4,16 +4,18 @@ import { message } from 'antd'
 import { getEthPrice, getDevEthPrice, getTokenDayDatas } from './client'
 import { UnwrapFunc } from 'src/fixtures/utility'
 
+const messageKey = 'theGraphAccess'
+
 export const useGetEthPrice = () => {
   const { data, error, mutate } = useSWR<UnwrapFunc<typeof getEthPrice>, Error>('getBundle', () => getEthPrice(), {
-    onError: err => message.error(err.message)
+    onError: err => message.error({ content: `failed to fetching eth price: ${err.message}`, key: messageKey })
   })
   return { data: new BigNumber(data?.ethPrice || '0'), error, mutate }
 }
 
 export const useGetDevEthPrice = () => {
   const { data, error, mutate } = useSWR<UnwrapFunc<typeof getDevEthPrice>, Error>('getToken', () => getDevEthPrice(), {
-    onError: err => message.error(err.message)
+    onError: err => message.error({ content: `failed to fetching dev eth price: ${err.message}`, key: messageKey })
   })
   return { data: new BigNumber(data?.derivedETH || '0'), error, mutate }
 }
@@ -22,13 +24,13 @@ export const useGetDevPrice = () => {
   const { data: ethPrice, error: ethPriceError } = useSWR<UnwrapFunc<typeof getEthPrice>, Error>(
     'getBundle',
     () => getEthPrice(),
-    { onError: err => message.error(err.message) }
+    { onError: err => message.error({ content: `failed to fetching bundle data: ${err.message}`, key: messageKey }) }
   )
 
   const { data: devEthPrice, error: devEthPriceError } = useSWR<UnwrapFunc<typeof getDevEthPrice>, Error>(
     'getToken',
     () => getDevEthPrice(),
-    { onError: err => message.error(err.message) }
+    { onError: err => message.error({ content: `failed to fetching token data: ${err.message}`, key: messageKey }) }
   )
 
   const devPrice = ethPrice && Number(ethPrice?.ethPrice) * Number(devEthPrice?.derivedETH)
@@ -40,7 +42,7 @@ export const useGetTokenDayDatas = () => {
     'getTokenDayDatas',
     () => getTokenDayDatas(),
     {
-      onError: err => message.error(err.message)
+      onError: err => message.error({ content: `failed to fetching token day data: ${err.message}`, key: messageKey })
     }
   )
   return { data: data, error, mutate }

--- a/packages/web/src/pages/_app.tsx
+++ b/packages/web/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import detectEthereumProvider from '@metamask/detect-provider'
 import WalletConnectProvider from '@walletconnect/web3-provider'
 import Fortmatic from 'fortmatic'
 import WalletLink from 'walletlink'
+import { message } from 'antd'
 import { WEB3_PROVIDER_ENDPOINT } from 'src/fixtures/wallet/constants'
 import { getAccountAddress } from 'src/fixtures/wallet/utility'
 
@@ -90,6 +91,10 @@ class NextApp extends App<AppInitialProps & WithApolloProps<{}>> {
   }
 
   componentDidMount = () => {
+    message.config({
+      maxCount: 5
+    })
+
     this.web3Modal = new Web3Modal({
       network: 'mainnet',
       cacheProvider: true,


### PR DESCRIPTION
## Proposed Changes
Fixes #869 

## Implementation
* Set the message key for processing on TheGraph and `devprtcl.xyz` access
* Improve error message
* Set the maximum number of messages to be displayed to 5.
    * Because any more messages displayed will only obscure the screen, and no action can be taken in response to the message.