### PR TITLE
Clear web3modal provider cache when MetaMask extension is not installed

### DIFF
--- a/packages/web/src/pages/_app.tsx
+++ b/packages/web/src/pages/_app.tsx
@@ -64,7 +64,7 @@ class NextApp extends App<AppInitialProps & WithApolloProps<{}>> {
 
   web3Modal: any
 
-  onWalletConnet = async () => {
+  onWalletConnect = async () => {
     const web3ForInjected: any = await detectEthereumProvider()
     if (!web3ForInjected) {
       return
@@ -98,7 +98,7 @@ class NextApp extends App<AppInitialProps & WithApolloProps<{}>> {
     this.setState({ web3Modal: this.web3Modal })
 
     if (this.web3Modal.cachedProvider === 'injected') {
-      this.onWalletConnet()
+      this.onWalletConnect()
     }
 
     const settings = localStorage.getItem('settings')

--- a/packages/web/src/pages/_app.tsx
+++ b/packages/web/src/pages/_app.tsx
@@ -67,6 +67,9 @@ class NextApp extends App<AppInitialProps & WithApolloProps<{}>> {
   onWalletConnect = async () => {
     const web3ForInjected: any = await detectEthereumProvider()
     if (!web3ForInjected) {
+      // NOTE: If the localStorage cache and metamask extension do not exist,
+      //       processing conflicts and will not be able to login, so clear the cache here.
+      this.web3Modal.clearCachedProvider()
       return
     }
     const isAuthorized = await getAccountAddress(new Web3(web3ForInjected))


### PR DESCRIPTION
## Proposed Changes
Fixes #876 

First, the type of Web3 Provider is cached in localStorage for signin (and login).
"injected" is cached in this cache when using the MetaMask extension.
A possible problem is when "injected" is stored in the cache, but the MetaMask extension is not installed in the browser.

To resolve this, if the MetaMask extension is not found and "injected" is cached in localStorage, clear the localStorage cache.

_Notice: But, it is unclear if this change will completely eliminate the problem._

## Implementation
