### PR TITLE
Use @apollo/client's gql

### DIFF
--- a/packages/graphql/src/react-apollo/generated.tsx
+++ b/packages/graphql/src/react-apollo/generated.tsx
@@ -5891,7 +5891,7 @@ export type ListPropertyQueryVariables = Exact<{
   ilike?: Maybe<Scalars['String']>
   from?: Maybe<Scalars['String']>
   market?: Maybe<Scalars['String']>
-  marketOther?: Maybe<Array<Scalars['String']>>
+  marketOther?: Maybe<Array<Scalars['String']> | Scalars['String']>
 }>
 
 export type ListPropertyQuery = { __typename?: 'query_root' } & {
@@ -5918,7 +5918,7 @@ export type ListPropertyOrderByMostRecentQueryVariables = Exact<{
   ilike?: Maybe<Scalars['String']>
   from?: Maybe<Scalars['String']>
   market?: Maybe<Scalars['String']>
-  marketOther?: Maybe<Array<Scalars['String']>>
+  marketOther?: Maybe<Array<Scalars['String']> | Scalars['String']>
 }>
 
 export type ListPropertyOrderByMostRecentQuery = { __typename?: 'query_root' } & {

--- a/packages/web/src/components/organisms/TopStakers/query/getTopStakersOfProperty.tsx
+++ b/packages/web/src/components/organisms/TopStakers/query/getTopStakersOfProperty.tsx
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 
 export const getTopStakersOfPropertyQuery = gql`
   query getTopStakersOfProperty($property_address: String!, $limit: Int!) {

--- a/packages/web/src/fixtures/uniswap/gql.tsx
+++ b/packages/web/src/fixtures/uniswap/gql.tsx
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 
 // see https://thegraph.com/explorer/subgraph/uniswap/uniswap-v2
 


### PR DESCRIPTION
## Proposed Changes

refs: https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/#graphql-tag

## Implementation
* change from `graphql-tag` to `@apollo/client`
* update `packages/graphql/src/react-apollo/generated.tsx`
  * refs: https://github.com/dotansimha/graphql-code-generator/issues/5352