### PR TITLE
change: from partial match to forward match with property search

### DIFF
--- a/packages/web/src/components/organisms/PropertyCardList/index.tsx
+++ b/packages/web/src/components/organisms/PropertyCardList/index.tsx
@@ -135,7 +135,7 @@ export const PropertyCardList = ({ currentPage, searchWord, sortBy, featureTag }
     variables: {
       limit: perPage,
       offset: (currentPage - 1) * perPage,
-      ilike: searchWord !== '' ? `%${searchWord}%` : undefined,
+      ilike: searchWord !== '' ? `${searchWord}%` : undefined,
       market: featureTag === 'GitHub' || featureTag === 'npm' ? markets[featureTag] : undefined,
       marketOther: featureTag === 'Creators' ? Object.values(markets) : undefined,
       // NOTE: If accountAddress is undefined, all properties will be displayed,
@@ -148,7 +148,7 @@ export const PropertyCardList = ({ currentPage, searchWord, sortBy, featureTag }
     variables: {
       limit: perPage,
       offset: (currentPage - 1) * perPage,
-      ilike: searchWord !== '' ? `%${searchWord}%` : undefined,
+      ilike: searchWord !== '' ? `${searchWord}%` : undefined,
       market: featureTag === 'GitHub' || featureTag === 'npm' ? markets[featureTag] : undefined,
       marketOther: featureTag === 'Creators' ? Object.values(markets) : undefined,
       from: sortBy === 'YOUR_PROPS' ? accountAddress || '0xdummy' : undefined


### PR DESCRIPTION
## Proposed Changes
Change the search for properties from partial match to forward match; suggested by @defi-er 

## Implementation
* change to `{WORD}%` from `%{WORD}%`