### PR TITLE
Add Patrons Onboarded on stats

### DIFF
--- a/packages/graphql/src/queries/listAccountLockup.graphql
+++ b/packages/graphql/src/queries/listAccountLockup.graphql
@@ -8,3 +8,11 @@ query listAccountLockup($account_address: String!, $offset: Int, $limit: Int!) {
     }
   }
 }
+
+query countAccountLockupUnique {
+  account_lockup_aggregate {
+    aggregate {
+      count(columns: account_address, distinct: true)
+    }
+  }
+}

--- a/packages/graphql/src/react-apollo/generated.tsx
+++ b/packages/graphql/src/react-apollo/generated.tsx
@@ -5876,6 +5876,16 @@ export type ListAccountLockupQuery = { __typename?: 'query_root' } & {
   }
 }
 
+export type CountAccountLockupUniqueQueryVariables = Exact<{ [key: string]: never }>
+
+export type CountAccountLockupUniqueQuery = { __typename?: 'query_root' } & {
+  account_lockup_aggregate: { __typename?: 'account_lockup_aggregate' } & {
+    aggregate?: Maybe<
+      { __typename?: 'account_lockup_aggregate_fields' } & Pick<Account_Lockup_Aggregate_Fields, 'count'>
+    >
+  }
+}
+
 export type ListOwnedPropertyMetaQueryVariables = Exact<{
   account_address: Scalars['String']
   offset?: Maybe<Scalars['Int']>
@@ -6294,6 +6304,55 @@ export function useListAccountLockupLazyQuery(
 export type ListAccountLockupQueryHookResult = ReturnType<typeof useListAccountLockupQuery>
 export type ListAccountLockupLazyQueryHookResult = ReturnType<typeof useListAccountLockupLazyQuery>
 export type ListAccountLockupQueryResult = Apollo.QueryResult<ListAccountLockupQuery, ListAccountLockupQueryVariables>
+export const CountAccountLockupUniqueDocument = gql`
+  query countAccountLockupUnique {
+    account_lockup_aggregate {
+      aggregate {
+        count(columns: account_address, distinct: true)
+      }
+    }
+  }
+`
+
+/**
+ * __useCountAccountLockupUniqueQuery__
+ *
+ * To run a query within a React component, call `useCountAccountLockupUniqueQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCountAccountLockupUniqueQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useCountAccountLockupUniqueQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useCountAccountLockupUniqueQuery(
+  baseOptions?: Apollo.QueryHookOptions<CountAccountLockupUniqueQuery, CountAccountLockupUniqueQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<CountAccountLockupUniqueQuery, CountAccountLockupUniqueQueryVariables>(
+    CountAccountLockupUniqueDocument,
+    options
+  )
+}
+export function useCountAccountLockupUniqueLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<CountAccountLockupUniqueQuery, CountAccountLockupUniqueQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<CountAccountLockupUniqueQuery, CountAccountLockupUniqueQueryVariables>(
+    CountAccountLockupUniqueDocument,
+    options
+  )
+}
+export type CountAccountLockupUniqueQueryHookResult = ReturnType<typeof useCountAccountLockupUniqueQuery>
+export type CountAccountLockupUniqueLazyQueryHookResult = ReturnType<typeof useCountAccountLockupUniqueLazyQuery>
+export type CountAccountLockupUniqueQueryResult = Apollo.QueryResult<
+  CountAccountLockupUniqueQuery,
+  CountAccountLockupUniqueQueryVariables
+>
 export const ListOwnedPropertyMetaDocument = gql`
   query listOwnedPropertyMeta($account_address: String!, $offset: Int, $limit: Int) {
     property_meta(

--- a/packages/web/src/components/organisms/DevStats/index.tsx
+++ b/packages/web/src/components/organisms/DevStats/index.tsx
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js'
 import React, { useMemo, useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { useGetDevPrice } from 'src/fixtures/uniswap/hooks'
-import { useListPropertyQuery } from '@dev/graphql'
+import { useListPropertyQuery, useCountAccountLockupUniqueQuery } from '@dev/graphql'
 import {
   useAPY,
   useAnnualSupplyGrowthRatio,
@@ -147,6 +147,12 @@ const AssetOnboarded = (_: {}) => {
   return data?.property_factory_create_aggregate ? <span>{formatAssetOnboarded.toFormat()}</span> : <></>
 }
 
+const PatronOnboarded = (_: {}) => {
+  const { data } = useCountAccountLockupUniqueQuery()
+  const formatPatronOnboarded = new BigNumber(data?.account_lockup_aggregate.aggregate?.count || 0)
+  return data?.account_lockup_aggregate ? <span>{formatPatronOnboarded.toFormat()}</span> : <></>
+}
+
 const CreatorsRewardsDev = (_: {}) => {
   const { creators } = useAPY()
   const { totalStakingAmount } = useTotalStakingAmountOnProtocol()
@@ -240,6 +246,14 @@ const items = [
     description: 'The total number of creator assets onboarded.',
     valueRender: function assetOnboardedRender() {
       return <AssetOnboarded />
+    }
+  },
+  {
+    title: 'PATRONS ONBOARDED',
+    unit: '',
+    description: 'The total number of patrons onboarded.',
+    valueRender: function patronOnboardedRender() {
+      return <PatronOnboarded />
     }
   },
   {


### PR DESCRIPTION
## Proposed Changes
for #1193 

<img width="1192" alt="patrons-onboarded-on-devstats" src="https://user-images.githubusercontent.com/150309/114363858-c87cb780-9bb3-11eb-8cb0-e76ef747da3c.png">

## Implementation
* add `PATRONS ONBOARDED` card. added next to `OSS PROJECTS ONBOARDED`
