### PR TITLE
Fix upload files

### DIFF
--- a/packages/web/src/fixtures/dev-for-apps/hooks.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.ts
@@ -296,8 +296,8 @@ export const useUploadPropertyCoverImages = (propertyAddress: string, accountAdd
   const { data: property, mutate } = useGetProperty(propertyAddress)
   const { postUploadFileHandler, isLoading, error } = useUploadFile(accountAddress)
 
-  const upload = async (file: any) => {
-    const refId = Number(property?.id)
+  const upload = async (file: any, propertyId?: number) => {
+    const refId = propertyId || Number(property?.id)
     const ref = 'Property'
     const field = 'cover_image'
     const path = `assets/${propertyAddress}/${field}`

--- a/packages/web/src/fixtures/dev-for-apps/hooks.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.ts
@@ -75,6 +75,7 @@ export const useCreateAccount = (walletAddress: string) => {
   const key = 'useCreateAccount'
   const { web3 } = useProvider()
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  const { mutate } = useGetAccount(walletAddress)
 
   const postAccountHandler = async (name?: string, biography?: string, website?: string, github?: string) => {
     const links: ProfileLinks = {
@@ -92,6 +93,7 @@ export const useCreateAccount = (walletAddress: string) => {
 
     const data = await postAccount(signedMessage, signature, walletAddress, name, biography, links)
       .then(result => {
+        mutate()
         message.success({ content: 'success update account data', key })
         return result
       })
@@ -112,6 +114,7 @@ export const useUpdateAccount = (id: number, walletAddress: string) => {
   const key = 'useUpdateAccount'
   const { web3 } = useProvider()
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  const { mutate } = useGetAccount(walletAddress)
 
   const putAccountHandler = async (name?: string, biography?: string, website?: string, github?: string) => {
     const links: ProfileLinks = {
@@ -129,6 +132,7 @@ export const useUpdateAccount = (id: number, walletAddress: string) => {
 
     const data = await putAccount(signedMessage, signature, walletAddress, id, name, biography, links)
       .then(result => {
+        mutate()
         message.success({ content: 'success update account data', key })
         return result
       })
@@ -149,8 +153,8 @@ export const useUploadAccountAvatar = (accountAddress: string) => {
   const { data: account, mutate } = useGetAccount(accountAddress)
   const { postUploadFileHandler, isLoading, error } = useUploadFile(accountAddress)
 
-  const upload = async (file: any) => {
-    const refId = Number(account?.id)
+  const upload = async (file: any, accountId?: number) => {
+    const refId = accountId || Number(account?.id)
     const ref = 'Account'
     const field = 'portrait'
     const path = `assets/${accountAddress}`
@@ -271,8 +275,8 @@ export const useUploadAccountCoverImages = (accountAddress: string) => {
   const { data: account, mutate } = useGetAccount(accountAddress)
   const { postUploadFileHandler, isLoading, error } = useUploadFile(accountAddress)
 
-  const upload = async (file: any) => {
-    const refId = Number(account?.id)
+  const upload = async (file: any, accountId?: number) => {
+    const refId = accountId || Number(account?.id)
     const ref = 'Account'
     const field = 'cover_images'
     const path = `assets/${accountAddress}/${field}`

--- a/packages/web/src/fixtures/dev-for-apps/hooks.ts
+++ b/packages/web/src/fixtures/dev-for-apps/hooks.ts
@@ -170,6 +170,7 @@ export const useCreateProperty = (walletAddress: string, propertyAddress: string
   const key = 'useCreateProperty'
   const { web3 } = useProvider()
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  const { mutate } = useGetProperty(propertyAddress)
 
   const postPropertyHandler = async (
     name?: string,
@@ -198,6 +199,7 @@ export const useCreateProperty = (walletAddress: string, propertyAddress: string
           message.error({ content: result.error, key })
           return
         }
+        mutate()
         message.success({ content: 'success update property data', key })
         return result
       })
@@ -218,6 +220,7 @@ export const useUpdateProperty = (id: number, walletAddress: string, propertyAdd
   const key = 'useUpdateProperty'
   const { web3 } = useProvider()
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  const { mutate } = useGetProperty(propertyAddress)
 
   const putPropertyHandler = async (
     name?: string,
@@ -255,6 +258,7 @@ export const useUpdateProperty = (id: number, walletAddress: string, propertyAdd
           message.error({ content: result.error, key })
           return
         }
+        mutate()
         message.success({ content: 'success update property data', key })
         return result
       })

--- a/packages/web/src/fixtures/dev-for-apps/utility.ts
+++ b/packages/web/src/fixtures/dev-for-apps/utility.ts
@@ -239,7 +239,7 @@ export const postProperty = (
       name,
       description,
       links,
-      wallet_address: address,
+      account_address: address,
       address: propertyAddress,
       signature,
       signMessage

--- a/packages/web/src/pages/author/[authorAddress]/edit.tsx
+++ b/packages/web/src/pages/author/[authorAddress]/edit.tsx
@@ -76,7 +76,8 @@ const ProfileForm = ({ accountAddress }: { accountAddress: string }) => {
   const handleChange = async (info: UploadChangeParam<UploadFile>) => {
     if (info.event) {
       const { displayName, biography, website, github } = pack(form)
-      const createdAccount = !data && found ? await createAccount(displayName, biography, website, github) : {}
+      const createdAccount =
+        !data && found ? await createAccount(displayName, biography, website, github) : { id: undefined }
       if (createdAccount === undefined) {
         return
       }
@@ -102,7 +103,8 @@ const ProfileForm = ({ accountAddress }: { accountAddress: string }) => {
   const handleCoverImageChange = async (info: UploadChangeParam<UploadFile>) => {
     if (info.event) {
       const { displayName, biography, website, github } = pack(form)
-      const createdAccount = !data && found ? await createAccount(displayName, biography, website, github) : {}
+      const createdAccount =
+        !data && found ? await createAccount(displayName, biography, website, github) : { id: undefined }
       if (createdAccount === undefined) {
         return
       }


### PR DESCRIPTION
## Proposed Changes

Solve the following three problems:
* Image upload fails when account data is not registered immediately after Sign-in.
* can't upload a account's cover image 
* Error when updating data immediately after property registration.

## Implementation
* Since  want to use the data for account/property in file upload, combined multiple components into one.
* If account/property data is not available before file upload, create it with the form data.