### PR TITLE
fix: next.js build warnings by next-transpile-modules

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -4,9 +4,7 @@ const fs = require('fs')
 const path = require('path')
 const withCss = require('@zeit/next-css')
 const withTM = require('next-transpile-modules')([
-  "@amcharts/amcharts4/core",
-  "@amcharts/amcharts4/charts",
-  "@amcharts/amcharts4/themes/animated"
+  "@amcharts/amcharts4"
 ])
 
 const themeVariables = lessToJS(fs.readFileSync(path.resolve(__dirname, './src/assets/antd-custom.less'), 'utf8'))


### PR DESCRIPTION
## Proposed Changes

Fix the following build warnings:
```
[build:next] next-transpile-modules - DEPRECATED - fallbacking to previous module resolution system for module "@amcharts/amcharts4/core", you can now just pass the name of the package to transpile and it will detect its real path without you having to pass a sub-module.
[build:next] next-transpile-modules - DEPRECATED - fallbacking to previous module resolution system for module "@amcharts/amcharts4/charts", you can now just pass the name of the package to transpile and it will detect its real path without you having to pass a sub-module.
[build:next] next-transpile-modules - DEPRECATED - fallbacking to previous module resolution system for module "@amcharts/amcharts4/themes/animated", you can now just pass the name of the package to transpile and it will detect its real path without you having to pass a sub-module.
```

refs: https://github.com/martpie/next-transpile-modules/releases/tag/7.1.0

## Implementation
* changed to specify only the package name

## Notes
* If the test passes and the operation is OK, self-merge