### PR TITLE
Improve: display estimated gas fee

### DIFF
--- a/packages/web/src/components/molecules/EstimatedGasFeeCard/EstimatedGas.tsx
+++ b/packages/web/src/components/molecules/EstimatedGasFeeCard/EstimatedGas.tsx
@@ -12,6 +12,7 @@ export const EstimatedGas = styled(Card)`
   .ant-card-body {
     font-size: 1rem;
     padding: 1rem 1.5rem;
+    text-align: right;
   }
   p {
     margin: 0;

--- a/packages/web/src/components/molecules/EstimatedGasFeeCard/index.tsx
+++ b/packages/web/src/components/molecules/EstimatedGasFeeCard/index.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Card } from 'antd'
+import { EstimatedGasNotes } from 'src/components/molecules/EstimatedGasNotes'
+
+interface Props {
+  estimatedGasFee: string
+  estimatedGasFeeUSD: string
+}
+
+export const EstimatedGas = styled(Card)`
+  background: transparent;
+  .ant-card-head {
+    padding: 0 1.5rem;
+  }
+  .ant-card-head-title {
+    font-size: 0.5rem 0;
+  }
+  .ant-card-body {
+    font-size: 1rem;
+    padding: 1rem 1.5rem;
+    text-align: right;
+  }
+  p {
+    margin: 0;
+  }
+`
+
+const EstimateGasUSD = styled.span`
+  font-size: 0.9em;
+  color: #a0a0a0;
+`
+
+export const EstimatedGasFeeCard = ({ estimatedGasFee, estimatedGasFeeUSD }: Props) => {
+  return (
+    <EstimatedGasNotes>
+      <EstimatedGas title="Gas Fee (this is prediction value)" size="small">
+        {
+          <p>
+            {estimatedGasFee ? estimatedGasFee : '-'} ETH
+            <EstimateGasUSD>{estimatedGasFeeUSD ? ` $${estimatedGasFeeUSD}` : ''}</EstimateGasUSD>
+          </p>
+        }
+      </EstimatedGas>
+    </EstimatedGasNotes>
+  )
+}

--- a/packages/web/src/components/molecules/TransactModalContents/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/molecules/TransactModalContents/__snapshots__/index.spec.tsx.snap
@@ -79,7 +79,7 @@ exports[`TransactModalContents Snapshot 1`] = `
           style="height: 40px;"
         />
         <div
-          class="ant-card ant-card-bordered ant-card-small sc-1fcc07h-0 kSZqNu"
+          class="ant-card ant-card-bordered ant-card-small sc-18v7ikh-0 eaHhNQ"
         >
           <div
             class="ant-card-head"
@@ -101,7 +101,7 @@ exports[`TransactModalContents Snapshot 1`] = `
               0.003345
                ETH
               <span
-                class="sc-1nbnut-0 flcZo"
+                class="sc-18v7ikh-1 kUJdSB"
               >
                  $0.00
               </span>

--- a/packages/web/src/components/organisms/Stake/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/Stake/__snapshots__/index.spec.tsx.snap
@@ -54,7 +54,7 @@ exports[`Stake Snapshot 1`] = `
         style="height: 40px;"
       />
       <div
-        class="ant-card ant-card-bordered ant-card-small sc-1fcc07h-0 kSZqNu"
+        class="ant-card ant-card-bordered ant-card-small sc-18v7ikh-0 eaHhNQ"
       >
         <div
           class="ant-card-head"
@@ -76,7 +76,7 @@ exports[`Stake Snapshot 1`] = `
             0.003345
              ETH
             <span
-              class="sc-1nbnut-0 flcZo"
+              class="sc-18v7ikh-1 kUJdSB"
             >
                $0.78
             </span>
@@ -147,7 +147,7 @@ exports[`Stake Snapshot with title 1`] = `
         style="height: 40px;"
       />
       <div
-        class="ant-card ant-card-bordered ant-card-small sc-1fcc07h-0 kSZqNu"
+        class="ant-card ant-card-bordered ant-card-small sc-18v7ikh-0 eaHhNQ"
       >
         <div
           class="ant-card-head"
@@ -169,7 +169,7 @@ exports[`Stake Snapshot with title 1`] = `
             0.003345
              ETH
             <span
-              class="sc-1nbnut-0 flcZo"
+              class="sc-18v7ikh-1 kUJdSB"
             >
                $0.78
             </span>

--- a/packages/web/src/components/organisms/Stake/index.tsx
+++ b/packages/web/src/components/organisms/Stake/index.tsx
@@ -1,14 +1,12 @@
 import React, { useCallback, useState, ChangeEvent, useMemo } from 'react'
-import styled from 'styled-components'
 import { useProvider } from 'src/fixtures/wallet/hooks'
 import { balanceOf } from 'src/fixtures/dev-kit/client'
 import { useStake, useGetEstimateGas4Stake } from 'src/fixtures/dev-kit/hooks'
 import { useGetEthPrice } from 'src/fixtures/uniswap/hooks'
 import { toAmountNumber, toNaturalNumber, whenDefinedAll } from 'src/fixtures/utility'
 import { TransactForm } from 'src/components/molecules/TransactForm'
-import { EstimatedGas } from 'src/components/molecules/TransactForm/EstimatedGas'
 import { FormContainer } from 'src/components/molecules/TransactForm/FormContainer'
-import { EstimatedGasNotes } from 'src/components/molecules/EstimatedGasNotes'
+import { EstimatedGasFeeCard } from 'src/components/molecules/EstimatedGasFeeCard'
 import { message } from 'antd'
 
 interface Props {
@@ -16,11 +14,6 @@ interface Props {
   title?: string
   propertyAddress: string
 }
-
-const EstimateGasUSD = styled.span`
-  font-size: 0.9em;
-  color: #a0a0a0;
-`
 
 export const Stake = ({ className, title, propertyAddress }: Props) => {
   const [stakeAmount, setStakeAmount] = useState<string>('')
@@ -72,16 +65,10 @@ export const Stake = ({ className, title, propertyAddress }: Props) => {
         onClickMax={onClickMax}
       />
       <div style={{ height: '40px' }}></div>
-      <EstimatedGasNotes>
-        <EstimatedGas title="Gas Fee (this is prediction value)" size="small">
-          {
-            <p>
-              {estimateGas ? estimateGas?.toFixed(6) : '-'} ETH
-              <EstimateGasUSD>{estimateGasUSD ? ` $${estimateGasUSD.toFixed(2)}` : ''}</EstimateGasUSD>
-            </p>
-          }
-        </EstimatedGas>
-      </EstimatedGasNotes>
+      <EstimatedGasFeeCard
+        estimatedGasFee={estimateGas ? estimateGas.toFixed(6) : '-'}
+        estimatedGasFeeUSD={estimateGasUSD ? estimateGasUSD.toFixed(2) : ''}
+      />
     </FormContainer>
   )
 }

--- a/packages/web/src/components/organisms/Withdraw/WithdrawWithEstimate.tsx
+++ b/packages/web/src/components/organisms/Withdraw/WithdrawWithEstimate.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState, useMemo } from 'react'
-import styled from 'styled-components'
 import {
   useGetMyStakingAmount,
   useGetMyStakingRewardAmount,
@@ -9,8 +8,7 @@ import { toBigNumber, whenDefined, whenDefinedAll } from 'src/fixtures/utility'
 import { useGetEthPrice } from 'src/fixtures/uniswap/hooks'
 import { FormContainer } from 'src/components/molecules/TransactForm/FormContainer'
 import { Estimated } from 'src/components/molecules/TransactForm/Estimated'
-import { EstimatedGas } from 'src/components/molecules/TransactForm/EstimatedGas'
-import { EstimatedGasNotes } from 'src/components/molecules/EstimatedGasNotes'
+import { EstimatedGasFeeCard } from 'src/components/molecules/EstimatedGasFeeCard'
 import { Withdraw } from '.'
 
 interface Props {
@@ -18,11 +16,6 @@ interface Props {
   title?: string
   propertyAddress: string
 }
-
-const EstimateGasUSD = styled.span`
-  font-size: 0.9em;
-  color: #a0a0a0;
-`
 
 export const WithdrawWithEstimate = ({ className, title, propertyAddress }: Props) => {
   const [withdrawAmount, setWithdrawAmount] = useState<string>('')
@@ -65,16 +58,10 @@ export const WithdrawWithEstimate = ({ className, title, propertyAddress }: Prop
     <FormContainer className={className}>
       <Withdraw propertyAddress={propertyAddress} title={title} onChange={onChange} />
       <Estimated title="Staked and Reward Amount">{estimatedValue}</Estimated>
-      <EstimatedGasNotes>
-        <EstimatedGas title="Gas Fee (this is prediction value)" size="small">
-          {
-            <p>
-              {estimateGas ? estimateGas?.toFixed(6) : '-'} ETH
-              <EstimateGasUSD>{estimateGasUSD ? ` $${estimateGasUSD.toFixed(2)}` : ''}</EstimateGasUSD>
-            </p>
-          }
-        </EstimatedGas>
-      </EstimatedGasNotes>
+      <EstimatedGasFeeCard
+        estimatedGasFee={estimateGas ? estimateGas.toFixed(6) : '-'}
+        estimatedGasFeeUSD={estimateGasUSD ? estimateGasUSD.toFixed(2) : ''}
+      />
     </FormContainer>
   )
 }

--- a/packages/web/src/components/organisms/Withdraw/WithdrawWithEstimate.tsx
+++ b/packages/web/src/components/organisms/Withdraw/WithdrawWithEstimate.tsx
@@ -24,7 +24,7 @@ export const WithdrawWithEstimate = ({ className, title, propertyAddress }: Prop
   const [withdrawableTokens, setWithdrawableTokens] = useState<string>('')
   const { dev: myStakingRewardAmount } = useGetMyStakingRewardAmount(propertyAddress)
   const { myStakingAmount } = useGetMyStakingAmount(propertyAddress)
-  const { estimateGas } = useGetEstimateGas4WithdrawStakingAmount(propertyAddress, withdrawAmount)
+  const { estimateGas } = useGetEstimateGas4WithdrawStakingAmount(propertyAddress, withdrawAmount || '0')
   const { data: ethPrice } = useGetEthPrice()
   const estimateGasUSD = useMemo(
     () => whenDefinedAll([estimateGas, ethPrice], ([gas, eth]) => gas.multipliedBy(eth)),

--- a/packages/web/src/components/organisms/Withdraw/__snapshots__/WithdrawWithEstimate.spec.tsx.snap
+++ b/packages/web/src/components/organisms/Withdraw/__snapshots__/WithdrawWithEstimate.spec.tsx.snap
@@ -116,7 +116,7 @@ exports[`WithdrawWithEstimate Snapshot 1`] = `
         </div>
       </div>
       <div
-        class="ant-card ant-card-bordered ant-card-small sc-1fcc07h-0 kSZqNu"
+        class="ant-card ant-card-bordered ant-card-small sc-18v7ikh-0 eaHhNQ"
       >
         <div
           class="ant-card-head"
@@ -138,7 +138,7 @@ exports[`WithdrawWithEstimate Snapshot 1`] = `
             0.002233
              ETH
             <span
-              class="sc-1erb4uu-0 kSrWVC"
+              class="sc-18v7ikh-1 kUJdSB"
             >
                $0.52
             </span>

--- a/packages/web/src/components/organisms/Withdraw/index.tsx
+++ b/packages/web/src/components/organisms/Withdraw/index.tsx
@@ -6,9 +6,8 @@ import { useGetEthPrice } from 'src/fixtures/uniswap/hooks'
 import { useWithdrawStaking, useGetEstimateGas4WithdrawStakingAmount } from 'src/fixtures/dev-kit/hooks'
 import { toAmountNumber, toNaturalNumber, whenDefinedAll } from 'src/fixtures/utility'
 import { TransactForm } from 'src/components/molecules/TransactForm'
-import { EstimatedGas } from 'src/components/molecules/TransactForm/EstimatedGas'
 import { FormContainer } from 'src/components/molecules/TransactForm/FormContainer'
-import { EstimatedGasNotes } from 'src/components/molecules/EstimatedGasNotes'
+import { EstimatedGasFeeCard } from 'src/components/molecules/EstimatedGasFeeCard'
 import { InfoCircleOutlined } from '@ant-design/icons'
 import { message } from 'antd'
 
@@ -32,11 +31,6 @@ const SubtitleContianer = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-`
-
-const EstimateGasUSD = styled.span`
-  font-size: 0.9em;
-  color: #a0a0a0;
 `
 
 export const Withdraw = ({ className, title, propertyAddress, onChange: onChangeAmount, isDisplayFee }: Props) => {
@@ -103,16 +97,10 @@ export const Withdraw = ({ className, title, propertyAddress, onChange: onChange
         </span>
       </SubtitleContianer>
       {isDisplayFee ? (
-        <EstimatedGasNotes>
-          <EstimatedGas title="Gas Fee (this is prediction value)" size="small">
-            {
-              <p>
-                {estimateGas ? estimateGas?.toFixed(6) : '-'} ETH
-                <EstimateGasUSD>{estimateGasUSD ? ` $${estimateGasUSD.toFixed(2)}` : ''}</EstimateGasUSD>
-              </p>
-            }
-          </EstimatedGas>
-        </EstimatedGasNotes>
+        <EstimatedGasFeeCard
+          estimatedGasFee={estimateGas ? estimateGas.toFixed(6) : '-'}
+          estimatedGasFeeUSD={estimateGasUSD ? estimateGasUSD.toFixed(2) : ''}
+        />
       ) : (
         <></>
       )}

--- a/packages/web/src/components/organisms/Withdraw/index.tsx
+++ b/packages/web/src/components/organisms/Withdraw/index.tsx
@@ -37,7 +37,7 @@ export const Withdraw = ({ className, title, propertyAddress, onChange: onChange
   const [withdrawAmount, setWithdrawAmount] = useState<string>('')
   const { web3, accountAddress } = useProvider()
   const { withdrawStaking } = useWithdrawStaking()
-  const { estimateGas } = useGetEstimateGas4WithdrawStakingAmount(propertyAddress, withdrawAmount)
+  const { estimateGas } = useGetEstimateGas4WithdrawStakingAmount(propertyAddress, withdrawAmount || '0')
   const { data: ethPrice } = useGetEthPrice()
   const estimateGasUSD = useMemo(
     () => whenDefinedAll([estimateGas, ethPrice], ([gas, eth]) => gas.multipliedBy(eth)),

--- a/packages/web/src/components/organisms/WithdrawalForHolders/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/WithdrawalForHolders/__snapshots__/index.spec.tsx.snap
@@ -45,7 +45,7 @@ exports[`WithdrawalForHolders Snapshot 1`] = `
         </div>
       </div>
       <div
-        class="ant-card ant-card-bordered ant-card-small sc-1fcc07h-0 kSZqNu"
+        class="ant-card ant-card-bordered ant-card-small sc-18v7ikh-0 eaHhNQ"
       >
         <div
           class="ant-card-head"
@@ -67,7 +67,7 @@ exports[`WithdrawalForHolders Snapshot 1`] = `
             0.000011
              ETH
             <span
-              class="sc-1bsb5df-0 iFbLVr"
+              class="sc-18v7ikh-1 kUJdSB"
             >
                $0.00
             </span>

--- a/packages/web/src/components/organisms/WithdrawalForHolders/index.tsx
+++ b/packages/web/src/components/organisms/WithdrawalForHolders/index.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo } from 'react'
-import styled from 'styled-components'
 import {
   useGetMyHolderAmount,
   useWithdrawHolderReward,
@@ -10,19 +9,13 @@ import { useGetEthPrice } from 'src/fixtures/uniswap/hooks'
 import { TransactForm } from 'src/components/molecules/TransactForm'
 import { FormContainer } from 'src/components/molecules/TransactForm/FormContainer'
 import { Estimated } from 'src/components/molecules/TransactForm/Estimated'
-import { EstimatedGas } from 'src/components/molecules/TransactForm/EstimatedGas'
-import { EstimatedGasNotes } from 'src/components/molecules/EstimatedGasNotes'
+import { EstimatedGasFeeCard } from 'src/components/molecules/EstimatedGasFeeCard'
 
 interface Props {
   className?: string
   title?: string
   propertyAddress: string
 }
-
-const EstimateGasUSD = styled.span`
-  font-size: 0.9em;
-  color: #a0a0a0;
-`
 
 export const WithdrawalForHolders = ({ className, title, propertyAddress }: Props) => {
   const { myHolderAmount } = useGetMyHolderAmount(propertyAddress)
@@ -53,16 +46,10 @@ export const WithdrawalForHolders = ({ className, title, propertyAddress }: Prop
         suffix="DEV"
       ></TransactForm>
       <Estimated title="Withdrawable Amount">{<p>{myHolderAmount?.toFixed() || 0} DEV</p>}</Estimated>
-      <EstimatedGasNotes>
-        <EstimatedGas title="Gas Fee (this is prediction value)" size="small">
-          {
-            <p>
-              {estimateGas ? estimateGas?.toFixed(6) : '-'} ETH
-              <EstimateGasUSD>{estimateGasUSD ? ` $${estimateGasUSD.toFixed(2)}` : ''}</EstimateGasUSD>
-            </p>
-          }
-        </EstimatedGas>
-      </EstimatedGasNotes>
+      <EstimatedGasFeeCard
+        estimatedGasFee={estimateGas ? estimateGas.toFixed(6) : '-'}
+        estimatedGasFeeUSD={estimateGasUSD ? estimateGasUSD.toFixed(2) : ''}
+      />
     </FormContainer>
   )
 }

--- a/packages/web/src/fixtures/dev-kit/hooks.ts
+++ b/packages/web/src/fixtures/dev-kit/hooks.ts
@@ -120,10 +120,8 @@ export const useGetEstimateGas4WithdrawHolderAmount = (propertyAddress: string) 
     () =>
       whenDefinedAll([web3, accountAddress], ([x, fromAddress]) =>
         getEstimateGas4WithdrawHolderAmount(x, propertyAddress, fromAddress)
-      ),
-    {
-      onError: err => message.error(err.message)
-    }
+      )
+    // NOTE: If an error occurs, nothing is done. Because it only displays the estimated gas price.
   )
   const { gasPrice } = useGetGasPrice()
   const estimateGas = useMemo(() => whenDefinedAll([data, gasPrice], ([x, g]) => toNaturalNumber(x).multipliedBy(g)), [
@@ -295,10 +293,8 @@ export const useGetEstimateGas4WithdrawStakingAmount = (propertyAddress: string,
     () =>
       whenDefinedAll([web3, accountAddress, amount], ([x, fromAddress, a]) =>
         amount !== '' ? getEstimateGas4WithdrawStakingAmount(x, propertyAddress, a, fromAddress) : undefined
-      ),
-    {
-      onError: err => message.error(err.message)
-    }
+      )
+    // NOTE: If an error occurs, nothing is done. Because it only displays the estimated gas price.
   )
   const { gasPrice } = useGetGasPrice()
   const estimateGas = useMemo(() => whenDefinedAll([data, gasPrice], ([x, g]) => toNaturalNumber(x).multipliedBy(g)), [
@@ -348,10 +344,8 @@ export const useGetEstimateGas4Stake = (propertyAddress: string, amount?: string
         return stakeAmount.toNumber() !== 0
           ? getEstimateGas4StakeDev(x, propertyAddress, stakeAmount.toFormat({ decimalSeparator: '' }), fromAddress)
           : undefined
-      }),
-    {
-      onError: err => message.error(err.message)
-    }
+      })
+    // NOTE: If an error occurs, nothing is done. Because it only displays the estimated gas price.
   )
   const { gasPrice } = useGetGasPrice()
   const estimateGas = useMemo(() => whenDefinedAll([data, gasPrice], ([x, g]) => toNaturalNumber(x).multipliedBy(g)), [
@@ -464,10 +458,8 @@ export const useGetEstimateGas4CreateProperty = (name: string, symbol: string, a
     () =>
       whenDefinedAll([web3, accountAddress], ([x, fromAddress]) =>
         getEstimateGas4CreateProperty(x, name, symbol, author, fromAddress)
-      ),
-    {
-      onError: err => message.error(err.message)
-    }
+      )
+    // NOTE: If an error occurs, nothing is done. Because it only displays the estimated gas price.
   )
   const { gasPrice } = useGetGasPrice()
   const estimateGas = useMemo(() => whenDefinedAll([data, gasPrice], ([x, g]) => toNaturalNumber(x).multipliedBy(g)), [
@@ -543,10 +535,8 @@ export const useGetEstimateGas4CreateAndAuthenticate = (marketAddress: string) =
     () =>
       whenDefinedAll([web3, accountAddress], ([x, fromAddress]) =>
         getEstimateGas4CreateAndAuthenticate(x, 'name', 'symbol', marketAddress, ['a', 'b', 'c'], fromAddress)
-      ),
-    {
-      onError: err => message.error(err.message)
-    }
+      )
+    // NOTE: If an error occurs, nothing is done. Because it only displays the estimated gas price.
   )
   const { gasPrice } = useGetGasPrice()
   const estimateGas = useMemo(() => whenDefinedAll([data, gasPrice], ([x, g]) => toNaturalNumber(x).multipliedBy(g)), [

--- a/packages/web/src/fixtures/dev-kit/hooks.ts
+++ b/packages/web/src/fixtures/dev-kit/hooks.ts
@@ -341,7 +341,7 @@ export const useGetEstimateGas4Stake = (propertyAddress: string, amount?: string
     () =>
       whenDefinedAll([web3, accountAddress, amount], ([x, fromAddress, a]) => {
         const stakeAmount = toAmountNumber(a)
-        return stakeAmount.toNumber() !== 0
+        return stakeAmount.toNumber() >= 0
           ? getEstimateGas4StakeDev(x, propertyAddress, stakeAmount.toFormat({ decimalSeparator: '' }), fromAddress)
           : undefined
       })

--- a/packages/web/src/fixtures/dev-kit/hooks.ts
+++ b/packages/web/src/fixtures/dev-kit/hooks.ts
@@ -124,10 +124,10 @@ export const useGetEstimateGas4WithdrawHolderAmount = (propertyAddress: string) 
     // NOTE: If an error occurs, nothing is done. Because it only displays the estimated gas price.
   )
   const { gasPrice } = useGetGasPrice()
-  const estimateGas = useMemo(() => whenDefinedAll([data, gasPrice], ([x, g]) => toNaturalNumber(x).multipliedBy(g)), [
-    gasPrice,
-    data
-  ])
+  const estimateGas = useMemo(
+    () => whenDefinedAll([data, gasPrice], ([x, g]) => toNaturalNumber(x).multipliedBy(g)),
+    [gasPrice, data]
+  )
 
   return { estimateGas, error }
 }
@@ -297,10 +297,10 @@ export const useGetEstimateGas4WithdrawStakingAmount = (propertyAddress: string,
     // NOTE: If an error occurs, nothing is done. Because it only displays the estimated gas price.
   )
   const { gasPrice } = useGetGasPrice()
-  const estimateGas = useMemo(() => whenDefinedAll([data, gasPrice], ([x, g]) => toNaturalNumber(x).multipliedBy(g)), [
-    gasPrice,
-    data
-  ])
+  const estimateGas = useMemo(
+    () => whenDefinedAll([data, gasPrice], ([x, g]) => toNaturalNumber(x).multipliedBy(g)),
+    [gasPrice, data]
+  )
 
   return { estimateGas, error }
 }
@@ -348,10 +348,10 @@ export const useGetEstimateGas4Stake = (propertyAddress: string, amount?: string
     // NOTE: If an error occurs, nothing is done. Because it only displays the estimated gas price.
   )
   const { gasPrice } = useGetGasPrice()
-  const estimateGas = useMemo(() => whenDefinedAll([data, gasPrice], ([x, g]) => toNaturalNumber(x).multipliedBy(g)), [
-    gasPrice,
-    data
-  ])
+  const estimateGas = useMemo(
+    () => whenDefinedAll([data, gasPrice], ([x, g]) => toNaturalNumber(x).multipliedBy(g)),
+    [gasPrice, data]
+  )
 
   return { estimateGas, error }
 }
@@ -462,10 +462,10 @@ export const useGetEstimateGas4CreateProperty = (name: string, symbol: string, a
     // NOTE: If an error occurs, nothing is done. Because it only displays the estimated gas price.
   )
   const { gasPrice } = useGetGasPrice()
-  const estimateGas = useMemo(() => whenDefinedAll([data, gasPrice], ([x, g]) => toNaturalNumber(x).multipliedBy(g)), [
-    gasPrice,
-    data
-  ])
+  const estimateGas = useMemo(
+    () => whenDefinedAll([data, gasPrice], ([x, g]) => toNaturalNumber(x).multipliedBy(g)),
+    [gasPrice, data]
+  )
   return { estimateGas, error }
 }
 
@@ -539,10 +539,10 @@ export const useGetEstimateGas4CreateAndAuthenticate = (marketAddress: string) =
     // NOTE: If an error occurs, nothing is done. Because it only displays the estimated gas price.
   )
   const { gasPrice } = useGetGasPrice()
-  const estimateGas = useMemo(() => whenDefinedAll([data, gasPrice], ([x, g]) => toNaturalNumber(x).multipliedBy(g)), [
-    gasPrice,
-    data
-  ])
+  const estimateGas = useMemo(
+    () => whenDefinedAll([data, gasPrice], ([x, g]) => toNaturalNumber(x).multipliedBy(g)),
+    [gasPrice, data]
+  )
 
   return { estimateGas, error }
 }


### PR DESCRIPTION
## Proposed Changes
@kazu80 's feedbacks

* Errors related to the display of the estimated gas fee will not be displayed in the message ([discord link](https://discord.com/channels/547215761341546497/755951133272571944/852736523946295327))
  * This is the same cause as problem #1385 .
* Gas prices should be right-justified ([discord link](https://discord.com/channels/547215761341546497/755951133272571944/852739679228264458))

<img width="522" alt="stake-modal-estimated-gas-fee-with-enable-value" src="https://user-images.githubusercontent.com/150309/121705616-c8dff300-cb0f-11eb-81dd-fcdeae4d2d28.png">

## Implementation
* remove error handling when get estimated gas fee
* add EstimatedGasFeeCard component
* refactoring