### PR TITLE
chore: added next configfile to eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ dist
 cjs
 esm
 __snapshots__
+next.config.js


### PR DESCRIPTION
## Proposed Changes

Added the next config file to the ignore file list, since eslint error alert was got for the next configfile. If we also need the js lint setting for this config file, I will add it in another PR.

## Implementation
