### PR TITLE
Disable useSWR's revalidateOnFocus and focusThrottleInterval options with web3 access

### DIFF
--- a/packages/web/src/fixtures/_pages/liquidity/geyser/hooks.ts
+++ b/packages/web/src/fixtures/_pages/liquidity/geyser/hooks.ts
@@ -51,7 +51,8 @@ export const useTotalRewards = (geyserAddress: string) => {
   const { nonConnectedWeb3: web3 } = useProvider()
   const { data, error } = useSWR<BigNumber, Error>(
     SWRCachePath.allTokensLocked(geyserAddress),
-    whenDefined(web3, x => getTokensLocked(x, geyserAddress)) || null
+    whenDefined(web3, x => getTokensLocked(x, geyserAddress)) || null,
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return {
     data,
@@ -121,7 +122,8 @@ export const useAllTokensClaimed = (geyserAddress: string) => {
   const { nonConnectedWeb3: web3, accountAddress } = useProvider()
   const { data, error } = useSWR<BigNumber, Error>(
     SWRCachePath.useAllTokensClaimed(geyserAddress, accountAddress),
-    whenDefined(web3, x => getAllTokensClaimed(x, geyserAddress)) || null
+    whenDefined(web3, x => getAllTokensClaimed(x, geyserAddress)) || null,
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return {
     data,
@@ -133,7 +135,8 @@ export const useTotalStakingShares = (geyserAddress: string) => {
   const { nonConnectedWeb3, accountAddress } = useProvider()
   const { data, error } = useSWR<undefined | UnwrapFunc<typeof totalStakingShares>, Error>(
     SWRCachePath.getTotalStakingShares(geyserAddress, accountAddress),
-    () => whenDefined(nonConnectedWeb3, x => totalStakingShares(x, geyserAddress))
+    () => whenDefined(nonConnectedWeb3, x => totalStakingShares(x, geyserAddress)),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return {
     data,
@@ -145,7 +148,8 @@ export const useTotalStaked = (geyserAddress: string) => {
   const { nonConnectedWeb3, accountAddress } = useProvider()
   const { data, error } = useSWR<undefined | UnwrapFunc<typeof totalStakingShares>, Error>(
     SWRCachePath.useTotalStaked(geyserAddress, accountAddress),
-    () => whenDefined(nonConnectedWeb3, x => totalStaked(x, geyserAddress))
+    () => whenDefined(nonConnectedWeb3, x => totalStaked(x, geyserAddress)),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return {
     data,
@@ -157,7 +161,8 @@ export const useUpdateAccounting = (geyserAddress: string) => {
   const { web3, accountAddress } = useProvider()
   const { data, error } = useSWR<undefined | UnwrapFunc<typeof updateAccounting>, Error>(
     SWRCachePath.getUpdateAccounting(geyserAddress, accountAddress),
-    () => whenDefined(web3, x => updateAccounting(x, geyserAddress))
+    () => whenDefined(web3, x => updateAccounting(x, geyserAddress)),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return {
     data,
@@ -169,7 +174,8 @@ export const useFinalUnlockSchedules = (geyserAddress: string) => {
   const { nonConnectedWeb3, accountAddress } = useProvider()
   const { data, error } = useSWR<undefined | UnwrapFunc<typeof finalUnlockSchedules>, Error>(
     SWRCachePath.getFinalUnlockSchedules(geyserAddress, accountAddress),
-    () => whenDefined(nonConnectedWeb3, x => finalUnlockSchedules(x, geyserAddress))
+    () => whenDefined(nonConnectedWeb3, x => finalUnlockSchedules(x, geyserAddress)),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return {
     data,
@@ -262,24 +268,30 @@ export const useRewardMultiplier = (geyserAddress: string) => {
     data: block,
     error: errorGetStaked,
     mutate
-  } = useSWR<number | undefined, Error>(SWRCachePath.getStaked(geyserAddress, accountAddress), () =>
-    whenDefinedAll([web3, accountAddress], ([client, address]) =>
-      getStaked(client, address, geyserAddress).then(allEvents => {
-        return allEvents[0]?.blockNumber
-      })
-    )
+  } = useSWR<number | undefined, Error>(
+    SWRCachePath.getStaked(geyserAddress, accountAddress),
+    () =>
+      whenDefinedAll([web3, accountAddress], ([client, address]) =>
+        getStaked(client, address, geyserAddress).then(allEvents => {
+          return allEvents[0]?.blockNumber
+        })
+      ),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   const { data: timestamp, error: errorGetBlock } = useSWR<number | undefined, Error>(
     SWRCachePath.getBlock(geyserAddress, block),
-    () => (block ? getBlock(block).then(Number) : undefined)
+    () => (block ? getBlock(block).then(Number) : undefined),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   const { data: bonusPeriod, error: errorBonusPeriodSec } = useSWR<undefined | BigNumber, Error>(
     SWRCachePath.getBonusPeriodSec(geyserAddress, accountAddress),
-    () => whenDefined(web3, x => bonusPeriodSec(x, geyserAddress))
+    () => whenDefined(web3, x => bonusPeriodSec(x, geyserAddress)),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   const { data: _startBonus, error: errorStartBonus } = useSWR<undefined | BigNumber, Error>(
     SWRCachePath.getStartBonus(geyserAddress, accountAddress),
-    () => whenDefined(web3, x => startBonus(x, geyserAddress))
+    () => whenDefined(web3, x => startBonus(x, geyserAddress)),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   const startBonusPct = _startBonus ? toBigNumber(_startBonus).div(100) : toBigNumber(0)
   const multiplier =
@@ -312,7 +324,8 @@ export const useTotalStakedFor = (geyserAddress: string) => {
     () =>
       whenDefinedAll([nonConnectedWeb3, accountAddress], ([client, address]) =>
         totalStakedFor(client, address, geyserAddress)
-      )
+      ),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return {
     data,
@@ -358,7 +371,8 @@ export const useUnstakeQuery = (geyserAddress: string, amount?: BigNumber) => {
   const { web3 } = useProvider()
   const { data, error } = useSWR<UnwrapFunc<typeof totalStakedFor> | undefined, Error>(
     SWRCachePath.unstakeQuery(geyserAddress, amount?.toFixed()),
-    () => whenDefined(web3, w3 => whenDefined(amount, x => unstakeQuery(w3, x, geyserAddress)))
+    () => whenDefined(web3, w3 => whenDefined(amount, x => unstakeQuery(w3, x, geyserAddress))),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return {
     data,

--- a/packages/web/src/fixtures/dev-kit/hooks.ts
+++ b/packages/web/src/fixtures/dev-kit/hooks.ts
@@ -72,7 +72,7 @@ export const useGetTotalRewardsAmount = (propertyAddress: string) => {
   const { data, error } = useSWR<undefined | UnwrapFunc<typeof getRewardsAmount>, Error>(
     SWRCachePath.getTotalRewardsAmount(propertyAddress, accountAddress),
     () => whenDefined(web3, x => getRewardsAmount(x, propertyAddress)),
-    { onError: err => message.error(err.message) }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return {
     totalRewardsAmount: whenDefined(data, x => toCurrency(toNaturalNumber(toNaturalNumber(x)))),
@@ -120,7 +120,8 @@ export const useGetEstimateGas4WithdrawHolderAmount = (propertyAddress: string) 
     () =>
       whenDefinedAll([web3, accountAddress], ([x, fromAddress]) =>
         getEstimateGas4WithdrawHolderAmount(x, propertyAddress, fromAddress)
-      )
+      ),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
     // NOTE: If an error occurs, nothing is done. Because it only displays the estimated gas price.
   )
   const { gasPrice } = useGetGasPrice()
@@ -140,7 +141,7 @@ export const useGetMyHolderAmount = (propertyAddress: string) => {
       whenDefinedAll([nonConnectedWeb3, accountAddress], ([client, account]) =>
         getMyHolderAmount(client, propertyAddress, account)
       ),
-    { onError: err => message.error(err.message) }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   const [withdrawable, , , total] = data || []
   return {
@@ -158,7 +159,7 @@ export const useGetHolderAmountByAddress = (propertyAddress: string, srcAddress?
       whenDefinedAll([nonConnectedWeb3, srcAddress], ([client, account]) =>
         getMyHolderAmount(client, propertyAddress, account)
       ),
-    { onError: err => message.error(err.message) }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   const [withdrawable, , , total] = data || []
   return {
@@ -173,7 +174,7 @@ export const useGetTreasuryAmount = (propertyAddress: string) => {
   const { data, error } = useSWR<UnwrapFunc<typeof getTreasuryAmount>, Error>(
     SWRCachePath.getTreasuryAmount(propertyAddress),
     () => whenDefined(nonConnectedWeb3, client => getTreasuryAmount(client, propertyAddress)),
-    { onError: err => message.error(err.message) }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return { treasuryAmount: data ? toNaturalNumber(data) : undefined, error }
 }
@@ -184,7 +185,7 @@ export const useGetTotalStakingAmount = (propertyAddress: string) => {
   const { data, error } = useSWR<UnwrapFunc<typeof getTotalStakingAmount>, Error>(
     SWRCachePath.getTotalStakingAmount(propertyAddress, accountAddress),
     () => whenDefined(nonConnectedWeb3, x => getTotalStakingAmount(x, propertyAddress)),
-    { onError: err => message.error(err.message) }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return { totalStakingAmount: whenDefined(data, x => toCurrency(toNaturalNumber(x))), currency, error }
 }
@@ -198,9 +199,7 @@ export const useGetMyStakingRewardAmount = (propertyAddress: string) => {
       whenDefinedAll([nonConnectedWeb3, accountAddress], ([client, account]) =>
         getMyStakingRewardAmount(client, propertyAddress, account)
       ),
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
 
   return {
@@ -220,9 +219,7 @@ export const useGetMyStakingAmount = (propertyAddress: string) => {
       whenDefinedAll([nonConnectedWeb3, accountAddress], ([client, account]) =>
         getMyStakingAmount(client, propertyAddress, account)
       ),
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
 
   return { myStakingAmount: whenDefined(data, x => toCurrency(toNaturalNumber(x))), currency, error }
@@ -293,7 +290,8 @@ export const useGetEstimateGas4WithdrawStakingAmount = (propertyAddress: string,
     () =>
       whenDefinedAll([web3, accountAddress, amount], ([x, fromAddress, a]) =>
         amount !== '' ? getEstimateGas4WithdrawStakingAmount(x, propertyAddress, a, fromAddress) : undefined
-      )
+      ),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
     // NOTE: If an error occurs, nothing is done. Because it only displays the estimated gas price.
   )
   const { gasPrice } = useGetGasPrice()
@@ -344,7 +342,8 @@ export const useGetEstimateGas4Stake = (propertyAddress: string, amount?: string
         return stakeAmount.toNumber() >= 0
           ? getEstimateGas4StakeDev(x, propertyAddress, stakeAmount.toFormat({ decimalSeparator: '' }), fromAddress)
           : undefined
-      })
+      }),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
     // NOTE: If an error occurs, nothing is done. Because it only displays the estimated gas price.
   )
   const { gasPrice } = useGetGasPrice()
@@ -361,7 +360,7 @@ export const useTotalStakingAmountOnProtocol = () => {
   const { data: stakingAmount, error } = useSWR<UnwrapFunc<typeof getTotalStakingAmountOnProtocol>, Error>(
     SWRCachePath.getTotalStakingAmountOnProtocol(accountAddress),
     () => whenDefined(nonConnectedWeb3, x => getTotalStakingAmountOnProtocol(x)),
-    { onError: err => message.error(err.message) }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return {
     totalStakingAmount: stakingAmount ? Number(stakingAmount) : undefined,
@@ -374,9 +373,7 @@ export const useTotalStakingRatio = () => {
   const { data: totalSupplyValue, error: totalSupplyError } = useSWR<UnwrapFunc<typeof totalSupply>, Error>(
     SWRCachePath.totalSupply(accountAddress),
     () => whenDefined(nonConnectedWeb3, x => totalSupply(x)),
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   const { data: stakingAmount, error: stakingAmountError } = useSWR<
     UnwrapFunc<typeof getTotalStakingAmountOnProtocol>,
@@ -384,9 +381,7 @@ export const useTotalStakingRatio = () => {
   >(
     SWRCachePath.getTotalStakingAmountOnProtocol(accountAddress),
     () => whenDefined(nonConnectedWeb3, x => getTotalStakingAmountOnProtocol(x)),
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return {
     totalStakingRatio: totalSupplyValue && stakingAmount ? Number(stakingAmount) / Number(totalSupplyValue) : undefined,
@@ -399,9 +394,7 @@ export const useStakingShare = (propertyAddress: string) => {
   const { data: inProperty, error: inPropertyError } = useSWR<UnwrapFunc<typeof getTotalStakingAmount>, Error>(
     SWRCachePath.getTotalStakingAmount(propertyAddress, accountAddress),
     () => whenDefined(nonConnectedWeb3, x => getTotalStakingAmount(x, propertyAddress)),
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   const { data: inProtocol, error: inProtocolError } = useSWR<
     UnwrapFunc<typeof getTotalStakingAmountOnProtocol>,
@@ -409,9 +402,7 @@ export const useStakingShare = (propertyAddress: string) => {
   >(
     SWRCachePath.getTotalStakingAmountOnProtocol(accountAddress),
     () => whenDefined(nonConnectedWeb3, x => getTotalStakingAmountOnProtocol(x)),
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return {
     stakingShare: inProperty && inProtocol ? Number(inProperty) / Number(inProtocol) : undefined,
@@ -458,7 +449,8 @@ export const useGetEstimateGas4CreateProperty = (name: string, symbol: string, a
     () =>
       whenDefinedAll([web3, accountAddress], ([x, fromAddress]) =>
         getEstimateGas4CreateProperty(x, name, symbol, author, fromAddress)
-      )
+      ),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
     // NOTE: If an error occurs, nothing is done. Because it only displays the estimated gas price.
   )
   const { gasPrice } = useGetGasPrice()
@@ -535,7 +527,8 @@ export const useGetEstimateGas4CreateAndAuthenticate = (marketAddress: string) =
     () =>
       whenDefinedAll([web3, accountAddress], ([x, fromAddress]) =>
         getEstimateGas4CreateAndAuthenticate(x, 'name', 'symbol', marketAddress, ['a', 'b', 'c'], fromAddress)
-      )
+      ),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
     // NOTE: If an error occurs, nothing is done. Because it only displays the estimated gas price.
   )
   const { gasPrice } = useGetGasPrice()
@@ -573,9 +566,7 @@ export const useAPY = () => {
   const { data: maxRewards, error: maxRewardsError } = useSWR<UnwrapFunc<typeof calculateMaxRewardsPerBlock>, Error>(
     SWRCachePath.calculateMaxRewardsPerBlock(accountAddress),
     () => whenDefined(nonConnectedWeb3, x => calculateMaxRewardsPerBlock(x).catch(() => '0')),
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   const { data: totalStaking, error: totalStakingError } = useSWR<
     UnwrapFunc<typeof getTotalStakingAmountOnProtocol>,
@@ -583,9 +574,7 @@ export const useAPY = () => {
   >(
     SWRCachePath.getTotalStakingAmountOnProtocol(accountAddress),
     () => whenDefined(nonConnectedWeb3, x => getTotalStakingAmountOnProtocol(x)),
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   const { data: holders, error: holdersError } = useSWR<UnwrapFunc<typeof holdersShare>, Error>(
     SWRCachePath.holdersShare(maxRewards, totalStaking),
@@ -593,9 +582,7 @@ export const useAPY = () => {
       maxRewards && totalStaking
         ? whenDefined(nonConnectedWeb3, x => holdersShare(x, maxRewards, totalStaking))
         : undefined,
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
 
   const stakers = maxRewards && holders ? new BigNumber(maxRewards).minus(new BigNumber(holders)) : undefined
@@ -611,9 +598,7 @@ export const useTotalSupply = () => {
   const { data: totalSupplyValue, error } = useSWR<UnwrapFunc<typeof totalSupply>, Error>(
     SWRCachePath.totalSupply(accountAddress),
     () => whenDefined(nonConnectedWeb3, x => totalSupply(x)),
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
 
   return { totalSupply: new BigNumber(totalSupplyValue || '0'), error }
@@ -624,9 +609,7 @@ export const useCirculatingSupply = () => {
   const { data: totalSupplyValue, error } = useSWR<UnwrapFunc<typeof totalSupply>, Error>(
     SWRCachePath.totalSupply(accountAddress),
     () => whenDefined(nonConnectedWeb3, x => totalSupply(x)),
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
 
   const circulatingSupplyValue = useCallback(async () => {
@@ -658,16 +641,12 @@ export const useAnnualSupplyGrowthRatio = () => {
   const { data: maxRewards, error: maxRewardsError } = useSWR<UnwrapFunc<typeof calculateMaxRewardsPerBlock>, Error>(
     SWRCachePath.calculateMaxRewardsPerBlock(accountAddress),
     () => whenDefined(nonConnectedWeb3, x => calculateMaxRewardsPerBlock(x).catch(() => '0')),
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   const { data: totalSupplyValue, error: totalSupplyError } = useSWR<UnwrapFunc<typeof totalSupply>, Error>(
     SWRCachePath.totalSupply(accountAddress),
     () => whenDefined(nonConnectedWeb3, x => totalSupply(x)),
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   const year = new BigNumber(2102400)
   const annualSupplyGrowthRatio =
@@ -706,9 +685,7 @@ export const usePropertyAuthor = (propertyAddress?: string) => {
   const { data, error } = useSWR<undefined | UnwrapFunc<typeof totalSupply>, Error>(
     shouldFetch ? SWRCachePath.propertyAuthor(propertyAddress, accountAddress) : null,
     () => whenDefinedAll([nonConnectedWeb3, propertyAddress], ([client, property]) => propertyAuthor(client, property)),
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
 
   return { author: data, error }
@@ -717,10 +694,13 @@ export const usePropertyAuthor = (propertyAddress?: string) => {
 export const useBalanceOf = () => {
   const { currency, toCurrency } = useCurrency()
   const { nonConnectedWeb3, accountAddress } = useProvider()
-  const { data, error } = useSWR<BigNumber | undefined, Error>(SWRCachePath.balanceOf(accountAddress), () =>
-    whenDefinedAll([nonConnectedWeb3, accountAddress], ([client, account]) =>
-      balanceOf(client, account).then(toBigNumber)
-    )
+  const { data, error } = useSWR<BigNumber | undefined, Error>(
+    SWRCachePath.balanceOf(accountAddress),
+    () =>
+      whenDefinedAll([nonConnectedWeb3, accountAddress], ([client, account]) =>
+        balanceOf(client, account).then(toBigNumber)
+      ),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   const humanizedDev = whenDefined(data, toNaturalNumber)
   const amount = toCurrency(humanizedDev)
@@ -730,12 +710,15 @@ export const useBalanceOf = () => {
 export const useAllClaimedRewards = () => {
   const { currency, toCurrency } = useCurrency()
   const { nonConnectedWeb3, accountAddress } = useProvider()
-  const { data, error } = useSWR<BigNumber | undefined, Error>(SWRCachePath.allClaimedRewards(accountAddress), () =>
-    whenDefinedAll([nonConnectedWeb3, accountAddress], ([client, account]) =>
-      allClaimedRewards(client, account).then(allEvents => {
-        return allEvents.reduce((a, c) => a.plus(c.returnValues.value), toBigNumber(0))
-      })
-    )
+  const { data, error } = useSWR<BigNumber | undefined, Error>(
+    SWRCachePath.allClaimedRewards(accountAddress),
+    () =>
+      whenDefinedAll([nonConnectedWeb3, accountAddress], ([client, account]) =>
+        allClaimedRewards(client, account).then(allEvents => {
+          return allEvents.reduce((a, c) => a.plus(c.returnValues.value), toBigNumber(0))
+        })
+      ),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   const humanizedDev = whenDefined(data, toNaturalNumber)
   const amount = toCurrency(humanizedDev)
@@ -751,9 +734,7 @@ export const usePropertyName = (propertyAddress?: string) => {
       validAddress(propertyAddress)
         ? whenDefinedAll([nonConnectedWeb3, propertyAddress], ([client, property]) => propertyName(client, property))
         : 'Foo',
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
 
   return { name: data, error }
@@ -767,9 +748,7 @@ export const usePropertySymbol = (propertyAddress?: string) => {
       validAddress(propertyAddress)
         ? whenDefinedAll([nonConnectedWeb3, propertyAddress], ([client, property]) => propertySymbol(client, property))
         : 'FOO',
-    {
-      onError: err => message.error(err.message)
-    }
+    { onError: err => message.error(err.message), revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
 
   return { symbol: data, error }
@@ -782,7 +761,8 @@ export const useBalanceOfProperty = (propertyAddress: string) => {
     () =>
       whenDefinedAll([nonConnectedWeb3, accountAddress], ([client, account]) =>
         balanceOfProperty(client, propertyAddress, account).then(toBigNumber)
-      )
+      ),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return { balance: data, error }
 }
@@ -794,7 +774,8 @@ export const useBalanceOfAccountProperty = (propertyAddress?: string, accountAdd
     () =>
       whenDefinedAll([nonConnectedWeb3, propertyAddress, accountAddress], ([client, property, account]) =>
         balanceOfProperty(client, property, account).then(toBigNumber)
-      )
+      ),
+    { revalidateOnFocus: false, focusThrottleInterval: 0 }
   )
   return { balance: data, error }
 }


### PR DESCRIPTION
## Proposed Changes
related issue: #1438 

This is the first workaround (access reduction).

Right now, almost all APIs use the `revalidateOnFocus` and `focusThrottleInterval` options as default settings, since we haven't done any optimization regarding the useSWR access options.

https://swr.vercel.app/docs/options#options

> revalidateOnFocus = true: auto revalidate when window gets focused
> focusThrottleInterval = 5000: only revalidate once during a time span

The default setting for `revalidateOnFocus` is to revalidate when the screen is manipulated and focus is given, which will result in API access.
The `focusThrottleInterval` option, by default, causes accesses to occur every 5 seconds, which also increases API accesses.

Therefore, by disabling these two options, API accesses will not occur unless explicitly reloaded by the browser after rendering on first touch.
As a result, you should be able to reduce Web3 access.

### Pros&Cons
* pros: reduce web3 access
* cons: reduce UX too

## Implementation
* useSWR's `focusThrottleInterval` option change from `5000` to `0`
* useSWR's `revalidateOnFocus` option change from `true` to `false`
