### PR TITLE
tiny design fix

### DIFF
--- a/packages/web/src/pages/[propertyAddress].tsx
+++ b/packages/web/src/pages/[propertyAddress].tsx
@@ -321,14 +321,13 @@ const PropertyAbout = ({
           <Twitter href={dataProperty?.links.twitter} target="_blank" rel="noopener noreferrer" />
         )}
         {dataProperty?.links?.website && (
-          <Button
-            style={{ marginLeft: '20px', padding: 3, width: '38px', height: '38px' }}
-            shape="circle"
-            icon={<LinkOutlined />}
-            href={dataProperty?.links.website}
-            target="_blank"
-            rel="noopener noreferrer"
-          />
+          <a href={dataProperty?.links.website} target="_blank" rel="noopener noreferrer">
+            <Button
+              style={{ marginLeft: '20px', padding: 3, width: '38px', height: '38px' }}
+              shape="circle"
+              icon={<LinkOutlined />}
+            />
+          </a>
         )}
       </LinksArea>
       <ResponsiveModal


### PR DESCRIPTION
## Proposed Changes
fix vertical centering for website's icon

before:
<img width="185" alt="before" src="https://user-images.githubusercontent.com/150309/130391291-1e6726d4-aa08-4769-980c-504b2ff2823c.png">

after:
<img width="215" alt="after" src="https://user-images.githubusercontent.com/150309/130391305-6f46d661-1104-4ba8-beb3-067c7e5ef156.png">

## Implementation
