### PR TITLE
fix: use non-connected web3 provider when don't get a connected web3 provider

### DIFF
--- a/packages/web/src/pages/index.tsx
+++ b/packages/web/src/pages/index.tsx
@@ -20,8 +20,8 @@ const StyledSupplySummary = styled(SupplySummary)`
 
 const Index = (_: Props) => {
   const router = useRouter()
-  const { ethersProvider } = useProvider()
-  const { name } = useDetectChain(ethersProvider)
+  const { ethersProvider, nonConnectedEthersL1Provider } = useProvider()
+  const { name } = useDetectChain(ethersProvider || nonConnectedEthersL1Provider)
   const { apy, creators } = useAPY()
   const { annualSupplyGrowthRatio } = useAnnualSupplyGrowthRatio()
   const page = useMemo(() => {


### PR DESCRIPTION
## Proposed Changes
* use L1 non-connected Web3 provider when not get a connected Web3 Provider (L1 or L2)

related issue: #1811 

## Implementation


before:
<img width="1268" alt="before" src="https://user-images.githubusercontent.com/150309/142004933-c8428b07-7340-4b00-aa02-2d908215d5c5.png">

after:
<img width="1335" alt="after" src="https://user-images.githubusercontent.com/150309/142004949-aadfaf5d-300b-4e53-9b55-1a06cd4710f2.png">

