### PR TITLE
fix early access header link on v3

### DIFF
--- a/packages/web/src/components/atoms/EarlyAccess/index.tsx
+++ b/packages/web/src/components/atoms/EarlyAccess/index.tsx
@@ -15,10 +15,15 @@ const Wrap = styled.div`
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
 `
 
+const ClickableText = styled.span`
+  color: white;
+  cursor: pointer;
+`
+
 export const EarlyAccess = () => (
   <Wrap>
     <Link href="https://stakes.social" passHref>
-      Switch to development version
+      <ClickableText>Switch to development version</ClickableText>
     </Link>
   </Wrap>
 )

--- a/packages/web/src/components/atoms/EarlyAccess/index.tsx
+++ b/packages/web/src/components/atoms/EarlyAccess/index.tsx
@@ -15,15 +15,10 @@ const Wrap = styled.div`
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
 `
 
-const ClickableText = styled.span`
-  color: white;
-  cursor: pointer;
-`
-
 export const EarlyAccess = () => (
   <Wrap>
     <Link href="https://stakes.social" passHref>
-      <ClickableText>Switch to development version</ClickableText>
+      <a style={{ color: 'white' }}>Switch to development version</a>
     </Link>
   </Wrap>
 )

--- a/packages/web/src/components/atoms/EarlyAccess/index.tsx
+++ b/packages/web/src/components/atoms/EarlyAccess/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import Link from 'next/link'
 import styled from 'styled-components'
 
 const Wrap = styled.div`
@@ -14,4 +15,10 @@ const Wrap = styled.div`
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
 `
 
-export const EarlyAccess = () => <Wrap>Beta Version</Wrap>
+export const EarlyAccess = () => (
+  <Wrap>
+    <Link href="https://stakes.social" passHref>
+      Switch to development version
+    </Link>
+  </Wrap>
+)

--- a/packages/web/src/components/organisms/AuthHeader/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/AuthHeader/__snapshots__/index.spec.tsx.snap
@@ -7,16 +7,16 @@ exports[`AuthHeader Snapshot 1`] = `
       style="position: sticky; top: 0px; width: 100%; z-index: 5;"
     >
       <header
-        class="sc-pVTFL cojRhi"
+        class="sc-furwcr dEfYgJ"
       >
         <div
-          class="sc-bqiRlB gIAOub"
+          class="sc-egiyK kYhVgg"
         >
           <header
-            class="sc-jrQzAO eyFPeo"
+            class="sc-pVTFL xEgAJ"
           >
             <div
-              class="sc-kDTinF fiqjHQ"
+              class="sc-jrQzAO kZuvhn"
             >
               <a
                 class="sc-bdvvtL bKEjhC"
@@ -37,7 +37,7 @@ exports[`AuthHeader Snapshot 1`] = `
               </a>
             </div>
             <div
-              class="sc-iqseJM fHgXHv"
+              class="sc-kDTinF kqfajw"
             >
               <svg
                 height="50"
@@ -116,20 +116,20 @@ exports[`AuthHeader Snapshot 1`] = `
       <div
         class="sc-iCfMLu fOyGKa"
       >
-        <span
-          class="sc-furwcr jIRdot"
+        <a
           href="https://stakes.social"
+          style="color: white;"
         >
           Switch to development version
-        </span>
+        </a>
       </div>
     </div>
     <div
-      class="sc-ksdxgE cQDpAx"
+      class="sc-bqiRlB joQuxJ"
       height="300"
     >
       <h2
-        class="sc-fotOHu hpFzqn"
+        class="sc-hBUSln jjFdcK"
       >
         Choose Market
       </h2>

--- a/packages/web/src/components/organisms/AuthHeader/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/AuthHeader/__snapshots__/index.spec.tsx.snap
@@ -7,16 +7,16 @@ exports[`AuthHeader Snapshot 1`] = `
       style="position: sticky; top: 0px; width: 100%; z-index: 5;"
     >
       <header
-        class="sc-furwcr dEfYgJ"
+        class="sc-pVTFL cojRhi"
       >
         <div
-          class="sc-egiyK kYhVgg"
+          class="sc-bqiRlB gIAOub"
         >
           <header
-            class="sc-pVTFL xEgAJ"
+            class="sc-jrQzAO eyFPeo"
           >
             <div
-              class="sc-jrQzAO kZuvhn"
+              class="sc-kDTinF fiqjHQ"
             >
               <a
                 class="sc-bdvvtL bKEjhC"
@@ -37,7 +37,7 @@ exports[`AuthHeader Snapshot 1`] = `
               </a>
             </div>
             <div
-              class="sc-kDTinF kqfajw"
+              class="sc-iqseJM fHgXHv"
             >
               <svg
                 height="50"
@@ -116,19 +116,20 @@ exports[`AuthHeader Snapshot 1`] = `
       <div
         class="sc-iCfMLu fOyGKa"
       >
-        <a
+        <span
+          class="sc-furwcr jIRdot"
           href="https://stakes.social"
         >
           Switch to development version
-        </a>
+        </span>
       </div>
     </div>
     <div
-      class="sc-bqiRlB joQuxJ"
+      class="sc-ksdxgE cQDpAx"
       height="300"
     >
       <h2
-        class="sc-hBUSln jjFdcK"
+        class="sc-fotOHu hpFzqn"
       >
         Choose Market
       </h2>

--- a/packages/web/src/components/organisms/AuthHeader/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/AuthHeader/__snapshots__/index.spec.tsx.snap
@@ -116,7 +116,11 @@ exports[`AuthHeader Snapshot 1`] = `
       <div
         class="sc-iCfMLu fOyGKa"
       >
-        Beta Version
+        <a
+          href="https://stakes.social"
+        >
+          Switch to development version
+        </a>
       </div>
     </div>
     <div

--- a/packages/web/src/components/organisms/Header/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/Header/__snapshots__/index.spec.tsx.snap
@@ -7,16 +7,16 @@ exports[`Header Snapshot 1`] = `
       style="position: sticky; top: 0px; width: 100%; z-index: 5;"
     >
       <header
-        class="sc-pVTFL cojRhi"
+        class="sc-furwcr dEfYgJ"
       >
         <div
-          class="sc-bqiRlB gIAOub"
+          class="sc-egiyK kYhVgg"
         >
           <header
-            class="sc-jrQzAO eyFPeo"
+            class="sc-pVTFL xEgAJ"
           >
             <div
-              class="sc-kDTinF fiqjHQ"
+              class="sc-jrQzAO kZuvhn"
             >
               <a
                 class="sc-bdvvtL bKEjhC"
@@ -37,7 +37,7 @@ exports[`Header Snapshot 1`] = `
               </a>
             </div>
             <div
-              class="sc-iqseJM fHgXHv"
+              class="sc-kDTinF kqfajw"
             >
               <svg
                 height="50"
@@ -116,12 +116,12 @@ exports[`Header Snapshot 1`] = `
       <div
         class="sc-iCfMLu fOyGKa"
       >
-        <span
-          class="sc-furwcr jIRdot"
+        <a
           href="https://stakes.social"
+          style="color: white;"
         >
           Switch to development version
-        </span>
+        </a>
       </div>
     </div>
   </div>

--- a/packages/web/src/components/organisms/Header/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/Header/__snapshots__/index.spec.tsx.snap
@@ -7,16 +7,16 @@ exports[`Header Snapshot 1`] = `
       style="position: sticky; top: 0px; width: 100%; z-index: 5;"
     >
       <header
-        class="sc-furwcr dEfYgJ"
+        class="sc-pVTFL cojRhi"
       >
         <div
-          class="sc-egiyK kYhVgg"
+          class="sc-bqiRlB gIAOub"
         >
           <header
-            class="sc-pVTFL xEgAJ"
+            class="sc-jrQzAO eyFPeo"
           >
             <div
-              class="sc-jrQzAO kZuvhn"
+              class="sc-kDTinF fiqjHQ"
             >
               <a
                 class="sc-bdvvtL bKEjhC"
@@ -37,7 +37,7 @@ exports[`Header Snapshot 1`] = `
               </a>
             </div>
             <div
-              class="sc-kDTinF kqfajw"
+              class="sc-iqseJM fHgXHv"
             >
               <svg
                 height="50"
@@ -116,11 +116,12 @@ exports[`Header Snapshot 1`] = `
       <div
         class="sc-iCfMLu fOyGKa"
       >
-        <a
+        <span
+          class="sc-furwcr jIRdot"
           href="https://stakes.social"
         >
           Switch to development version
-        </a>
+        </span>
       </div>
     </div>
   </div>

--- a/packages/web/src/components/organisms/Header/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/Header/__snapshots__/index.spec.tsx.snap
@@ -116,7 +116,11 @@ exports[`Header Snapshot 1`] = `
       <div
         class="sc-iCfMLu fOyGKa"
       >
-        Beta Version
+        <a
+          href="https://stakes.social"
+        >
+          Switch to development version
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Proposed Changes

## Implementation
* Link to https://stakes.social
* text change to `Switch to development version`