### PR TITLE
Fix the bugs on APY

### DIFF
--- a/packages/web/src/fixtures/dev-kit/hooks.ts
+++ b/packages/web/src/fixtures/dev-kit/hooks.ts
@@ -620,7 +620,7 @@ export const useAPY = () => {
   )
 
   const stakers = maxRewards && holders ? new BigNumber(maxRewards).minus(new BigNumber(holders)) : undefined
-  const year = new BigNumber(isL1 ? 2102400 : 31536000)
+  const year = useMemo(() => new BigNumber(isL1 || isL1 === undefined ? 2102400 : 31536000), [isL1])
   const apy = stakers && totalStaking ? stakers.times(year).div(totalStaking).times(100) : undefined
   const creators = holders && totalStaking ? new BigNumber(holders).times(year).div(totalStaking).times(100) : undefined
 
@@ -716,7 +716,7 @@ export const useAnnualSupplyGrowthRatio = () => {
       focusThrottleInterval: 0
     }
   )
-  const year = new BigNumber(isL1 ? 2102400 : 31536000)
+  const year = useMemo(() => new BigNumber(isL1 || isL1 === undefined ? 2102400 : 31536000), [isL1])
   const annualSupplyGrowthRatio =
     maxRewards && totalSupplyValue ? new BigNumber(maxRewards).times(year).div(totalSupplyValue).times(100) : undefined
 

--- a/packages/web/src/fixtures/wallet/hooks.ts
+++ b/packages/web/src/fixtures/wallet/hooks.ts
@@ -82,6 +82,6 @@ export const useDetectChain = (ethersProvider?: providers.BaseProvider) => {
 export const useIsL1 = () => {
   const { ethersProvider } = useProvider()
   const { name: chain } = useDetectChain(ethersProvider)
-  const isL1 = useMemo(() => chain === 'ethereum', [chain])
+  const isL1 = useMemo(() => whenDefined(chain, c => c === 'ethereum'), [chain])
   return { isL1 }
 }


### PR DESCRIPTION
## Proposed Changes

- If I load the front page when the wallet is not connected, APY shows incorrect numbers. Fix this issue.

## Implementation

- `useIsL1` returns `UndefinedOr<boolean>`
- When `useIsL1().isL1` is `true` or `undefined`, calculate the APY as the mainnet