### PR TITLE
feat: rename discord name to discord username

### DIFF
--- a/packages/web/src/components/organisms/InvitationRequestForm/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/InvitationRequestForm/__snapshots__/index.spec.tsx.snap
@@ -426,7 +426,7 @@ exports[`InvitationRequestForm Snapshot 1`] = `
             <span
               style="font-size: 1.1em;"
             >
-              Discord name:
+              Discord username:
             </span>
           </div>
           <div
@@ -480,7 +480,7 @@ exports[`InvitationRequestForm Snapshot 1`] = `
                           <input
                             class="sc-hKwDye bghYKm"
                             id="basic_discord"
-                            placeholder="discord name"
+                            placeholder="discord username"
                             value=""
                           />
                         </div>

--- a/packages/web/src/components/organisms/InvitationRequestForm/index.tsx
+++ b/packages/web/src/components/organisms/InvitationRequestForm/index.tsx
@@ -214,10 +214,10 @@ export const InvitationRequestForm = ({ market }: Props) => {
               <Span style={{ marginTop: 0, fontSize: '1.1em' }}>
                 <a href="https://discord.gg/VwJp4KM">Dev Protocol</a>
               </Span>
-              <span style={{ fontSize: '1.1em' }}>Discord name:</span>
+              <span style={{ fontSize: '1.1em' }}>Discord username:</span>
             </div>
             <Form.Item name="discord" rules={[{ required: true, type: 'string' }]} key="discord">
-              <Input Icon={MessageOutlined} placeholder="discord name" label="discord" />
+              <Input Icon={MessageOutlined} placeholder="discord username" label="discord" />
             </Form.Item>
           </Row>
           <Row>


### PR DESCRIPTION
## Proposed Changes
Rename `Discord name` to `Discord username`
![proposed](https://user-images.githubusercontent.com/28766927/148789426-5a6a8b57-5bbd-4642-84f1-546f889aae8d.png)

## Implementation
<img width="530" alt="username" src="https://user-images.githubusercontent.com/28766927/148789307-b0f3fc1a-8462-4015-bde0-7367c0a45074.png">

