### PR TITLE
Remove Ropsten from the network selector

### DIFF
--- a/packages/web/src/components/molecules/Navigation/index.tsx
+++ b/packages/web/src/components/molecules/Navigation/index.tsx
@@ -215,10 +215,6 @@ export const Navigation = () => {
             <Popover
               content={
                 <>
-                  <NetworkSwitch type="link" onClick={switchNetwork('ropsten')}>
-                    <ConnectedOrDisconnected chainName="ropsten" />
-                    <span>Ropsten</span>
-                  </NetworkSwitch>
                   <NetworkSwitch type="link" onClick={switchNetwork('arbitrum-rinkeby')}>
                     <ConnectedOrDisconnected chainName="arbitrum-rinkeby" />
                     <span>Arbitrum Rinkeby</span>


### PR DESCRIPTION
## Proposed Changes

Remove Ropsten from the network selector.

Dev Protocol on Ropsten network is still available and Stakes.social supports it, but if the user uses it as a testnet, Arbitrum or Polygon is easier to use, so removing Ropsten from the UI is better.

## Implementation

- Update `packages/web/src/components/molecules/Navigation/index.tsx`