### PR TITLE
Use Service Worker for rpc endpoints

### DIFF
--- a/packages/web/public/sw.js
+++ b/packages/web/public/sw.js
@@ -1,0 +1,31 @@
+const APIS = 'alchemyapi.io'
+const TS = 60000
+const requests = new Map()
+
+const keyByRequest = async event => `${event.request.url}/${JSON.stringify(await event.request.clone().json())}`
+const handler = async event => {
+  const key = await keyByRequest(event)
+  const { request } = event
+  if (!requests.get(key)) {
+    requests.set(key, fetch(request.clone()))
+    setTimeout(() => {
+      console.debug('purge cache', key)
+      requests.delete(key)
+    }, TS)
+
+    return fetch(request)
+  }
+
+  const result = (await requests.get(key)).clone()
+  console.debug('cached', key)
+  return result
+}
+
+self.addEventListener('fetch', async event => {
+  const {
+    request: { url }
+  } = event
+  if (url.includes(APIS)) {
+    event.respondWith(handler(event))
+  }
+})

--- a/packages/web/public/sw.js
+++ b/packages/web/public/sw.js
@@ -8,12 +8,11 @@ const handler = async event => {
   const { request } = event
   if (!requests.get(key)) {
     requests.set(key, fetch(request.clone()))
+    console.debug('send request', key)
     setTimeout(() => {
       console.debug('purge cache', key)
       requests.delete(key)
     }, TS)
-
-    return fetch(request)
   }
 
   const result = (await requests.get(key)).clone()

--- a/packages/web/src/pages/_app.tsx
+++ b/packages/web/src/pages/_app.tsx
@@ -105,6 +105,18 @@ class NextApp extends App<AppInitialProps & WithApolloProps<{}>> {
   }
 
   componentDidMount = () => {
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', function () {
+        navigator.serviceWorker.register('/sw.js').then(
+          registration => {
+            console.log('Service Worker registration successful with scope: ', registration.scope)
+          },
+          err => {
+            console.log('Service Worker registration failed: ', err)
+          }
+        )
+      })
+    }
     message.config({
       maxCount: 5
     })


### PR DESCRIPTION
## Proposed Changes

- Use Service Worker for RPC endpoints to cache similar many requests

## Implementation

- add `/sw.js` to Next app
- install the Service Worker